### PR TITLE
fix(docs): remove extra left margin on docs sidebar

### DIFF
--- a/apps/docs/app/docs/layout.tsx
+++ b/apps/docs/app/docs/layout.tsx
@@ -9,6 +9,16 @@ export default function Layout({ children }: LayoutProps<'/docs'>) {
       tabs={{
         transform: (option) => ({ ...option, description: undefined }),
       }}
+      containerProps={{
+        style: {
+          gridTemplate: `"sidebar header toc"
+"sidebar toc-popover toc"
+"sidebar main toc" 1fr / var(--fd-sidebar-col) minmax(0, 1fr) var(--fd-toc-width)`,
+        },
+      }}
+      sidebar={{
+        className: '!items-stretch',
+      }}
       {...baseOptions()}
     >
       {children}


### PR DESCRIPTION
## Summary

Patches the ZBSearch docs site to fix a Fumadocs layout bug and remove the default Orama search dependency — a stepping stone toward wiring docs search through **ZBSearch** instead of `@orama/orama`.

### 1. Sidebar layout fix

Fumadocs' default docs grid uses a centered layout where the sidebar spans a flexible left column **plus** the sidebar column, leaving a large empty gap (~337px on wide screens) before the nav content.

Override the container grid to a 3-column layout (`sidebar | main | toc`) and stretch the sidebar panel so links align flush left.

### 2. Orama → ZBSearch patch

Fumadocs' built-in search statically imports `@orama/orama`, which is not declared in the docs package and breaks a clean checkout build. This patch:

- Disables Fumadocs' default Orama search UI via `RootProvider` + a no-op `SearchDialog` stub
- Aliases `@orama/orama` to a local no-op module so Turbopack can compile without installing Orama

This unblocks the docs build today. The follow-up is to plug in a ZBSearch-backed search dialog and API route (using `zbsearch` for indexing + query) so the docs site dogfoods its own search engine.

## Before / After

- **Sidebar:** nav links no longer start ~350px from the left on wide viewports
- **Search:** docs build no longer requires `@orama/orama`; default Orama search is disabled pending ZBSearch integration

## Test plan

- [ ] Open any `/docs/*` page on a wide (>1280px) viewport and confirm the sidebar is flush left with no dead space
- [ ] Confirm the main content and TOC columns are unaffected
- [ ] Check narrow / mobile viewports still collapse the sidebar correctly
- [ ] Run `pnpm --filter docs dev` on a clean checkout — build should succeed without `@orama/orama` installed
- [ ] Confirm ⌘K / search shortcut does not surface the broken Orama dialog (stub returns null)