### PR TITLE
feat: Orama vs ZBSearch comparison benchmarks + on-demand workflow

### DIFF
--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -1,0 +1,91 @@
+name: Orama vs ZBSearch Benchmarks
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Benchmark sampling mode
+        required: true
+        default: full
+        type: choice
+        options:
+          - full
+          - quick
+      format:
+        description: Table format printed in the job log
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - markdown
+          - ascii
+
+permissions:
+  contents: read
+
+jobs:
+  compare:
+    name: Orama vs ZBSearch
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install monorepo dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build packages used by benchmarks
+        run: |
+          pnpm --filter zbsearch build
+          pnpm --filter @zbsearch/stopwords build
+
+      - name: Install benchmark dependencies
+        working-directory: benchmarks
+        run: |
+          npm install
+          # Always compare against the latest published Orama release
+          npm install @orama/orama@latest
+
+      - name: Print versions under test
+        working-directory: benchmarks
+        run: |
+          node -e "
+            import { createRequire } from 'node:module'
+            const require = createRequire(import.meta.url)
+            console.log('Orama   ', require('@orama/orama/package.json').version)
+            console.log('ZBSearch', require('zbsearch/package.json').version)
+            console.log('Node    ', process.version)
+          "
+
+      - name: Run comparison benchmarks
+        working-directory: benchmarks
+        env:
+          BENCHMARK_MODE: ${{ inputs.mode }}
+        run: |
+          EXTRA_ARGS=()
+          if [ "${{ inputs.mode }}" = "quick" ]; then
+            EXTRA_ARGS+=(--quick)
+          fi
+          EXTRA_ARGS+=(--format=${{ inputs.format }})
+          EXTRA_ARGS+=(--json)
+          EXTRA_ARGS+=(--out=benchmark/orama-vs-zbsearch.json)
+          node compare.js "${EXTRA_ARGS[@]}"
+
+      - name: Upload JSON results
+        uses: actions/upload-artifact@v4
+        with:
+          name: orama-vs-zbsearch-benchmarks
+          path: |
+            benchmarks/benchmark/orama-vs-zbsearch.json
+          if-no-files-found: warn

--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -54,7 +54,6 @@ jobs:
         working-directory: benchmarks
         run: |
           npm install
-          # Always compare against the latest published Orama release
           npm install @orama/orama@latest
 
       - name: Print versions under test

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,48 @@
+# Benchmarks
+
+Head-to-head and multi-engine performance suites for ZBSearch.
+
+## Orama vs ZBSearch (recommended)
+
+Compares the latest published `@orama/orama` against the local `zbsearch` build across indexing, search variants, geosearch, memory, and bundle size.
+
+```sh
+# From repo root
+pnpm --filter zbsearch build
+pnpm --filter @zbsearch/stopwords build
+
+cd benchmarks
+npm install
+npm run benchmark:compare        # full run + JSON report
+npm run benchmark:compare:quick  # shorter sampling windows
+```
+
+Options:
+
+```sh
+node compare.js --format=markdown
+node compare.js --format=ascii
+node compare.js --format=both
+node compare.js --json --out=benchmark/orama-vs-zbsearch.json
+node compare.js --quick
+```
+
+### GitHub Actions
+
+Run **Orama vs ZBSearch Benchmarks** via `workflow_dispatch` (Actions → workflow → Run workflow).
+
+The job prints Markdown + ASCII tables in the log, writes the Markdown table to the job summary, and uploads `orama-vs-zbsearch.json` as an artifact.
+
+## Other suites
+
+| Script | Description |
+| --- | --- |
+| `npm run benchmark` | Multi-engine insert/search (Orama, ZBSearch, FlexSearch, Fuse, Lunr, MiniSearch) |
+| `npm run benchmark:facets` | Faceted search |
+| `npm run benchmark:bkd` | BKD / geopoint tree |
+| `npm run benchmark:avl` | AVL tree |
+| `npm run benchmark:vector` | Vector search |
+| `npm run benchmark:vector-ivf` | IVF vector index |
+| `npm run benchmark:memory` | Memory footprint |
+| `npm run benchmark:bundle-size` | Serialized index size |
+| `npm run benchmark:algorithms` | BM25 / QPS / PT15 |

--- a/benchmarks/compare.js
+++ b/benchmarks/compare.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Orama vs ZBSearch head-to-head comparison.
+ *
+ * Usage:
+ *   node compare.js
+ *   node compare.js --format=markdown
+ *   node compare.js --format=ascii
+ *   node compare.js --format=both
+ *   node compare.js --json
+ *   node compare.js --quick   # shorter sampling windows for local smoke runs
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { runComparisonSuites } from './src/compare/suites.js'
+import {
+  compareRow,
+  toMarkdownTable,
+  toAsciiTable,
+  summarizeWinners
+} from './src/compare/table.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function parseArgs(argv) {
+  const args = {
+    format: 'both',
+    json: false,
+    quick: false,
+    out: null
+  }
+
+  for (const arg of argv) {
+    if (arg === '--json') args.json = true
+    else if (arg === '--quick') args.quick = true
+    else if (arg.startsWith('--format=')) args.format = arg.slice('--format='.length)
+    else if (arg.startsWith('--out=')) args.out = arg.slice('--out='.length)
+  }
+
+  return args
+}
+
+const args = parseArgs(process.argv.slice(2))
+
+console.error('Running Orama vs ZBSearch comparison benchmarks...')
+console.error(`Dataset: games index · Node ${process.version} · ${process.platform}/${process.arch}`)
+if (args.quick) {
+  console.error('Mode: quick (shorter sampling windows)')
+}
+console.error('')
+
+const suiteOptions = args.quick
+  ? { opsDurationMs: 250, opsWarmupMs: 50, indexIterations: 3 }
+  : { opsDurationMs: 900, opsWarmupMs: 200, indexIterations: 10 }
+
+const started = performance.now()
+const report = runComparisonSuites(suiteOptions)
+const elapsedSec = ((performance.now() - started) / 1000).toFixed(1)
+
+const rows = report.results.map((result) =>
+  compareRow({
+    name: result.name,
+    unit: result.unit,
+    orama: result.orama,
+    zbsearch: result.zbsearch,
+    higherIsBetter: result.higherIsBetter
+  })
+)
+
+const meta = {
+  title: 'Orama vs ZBSearch Benchmarks',
+  oramaVersion: report.versions.orama,
+  zbsearchVersion: report.versions.zbsearch
+}
+
+const winners = summarizeWinners(rows)
+const markdown = [
+  toMarkdownTable(rows, meta),
+  '',
+  '> Speed metrics are ops/sec (higher is better). Indexing/remove are median latency (lower is better). Memory and bundle sizes are bytes (lower is better).',
+  '',
+  `**Records:** ${report.records.toLocaleString()} · **Node:** ${report.meta.node} · **Platform:** ${report.meta.platform}`,
+  '',
+  `**Wins:** ZBSearch ${winners.ZBSearch} · Orama ${winners.Orama} · Ties ${winners.tie}`,
+  '',
+  `_Completed in ${elapsedSec}s on ${report.meta.date}_`
+].join('\n')
+
+const ascii = [
+  toAsciiTable(rows, meta),
+  '',
+  'Speed = ops/sec (higher better) | Indexing/remove = latency (lower better) | Memory/bundle = bytes (lower better)',
+  `Records: ${report.records.toLocaleString()}  Node: ${report.meta.node}  Platform: ${report.meta.platform}`,
+  `Wins: ZBSearch ${winners.ZBSearch}  Orama ${winners.Orama}  Ties ${winners.tie}`,
+  `Completed in ${elapsedSec}s`
+].join('\n')
+
+if (args.format === 'markdown' || args.format === 'both') {
+  console.log(markdown)
+  if (args.format === 'both') console.log('')
+}
+
+if (args.format === 'ascii' || args.format === 'both') {
+  console.log(ascii)
+}
+
+if (args.json || args.out) {
+  const payload = {
+    ...report,
+    table: rows,
+    winners,
+    elapsedSec: Number(elapsedSec)
+  }
+
+  const outPath =
+    args.out ??
+    join(__dirname, 'benchmark', 'orama-vs-zbsearch.json')
+
+  mkdirSync(dirname(outPath), { recursive: true })
+  writeFileSync(outPath, `${JSON.stringify(payload, null, 2)}\n`)
+  console.error(`\nWrote JSON report to ${outPath}`)
+}
+
+// Expose markdown for GitHub Actions step summaries via stdout marker
+if (process.env.GITHUB_STEP_SUMMARY) {
+  writeFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`, { flag: 'a' })
+}

--- a/benchmarks/compare.js
+++ b/benchmarks/compare.js
@@ -1,15 +1,4 @@
 #!/usr/bin/env node
-/**
- * Orama vs ZBSearch head-to-head comparison.
- *
- * Usage:
- *   node compare.js
- *   node compare.js --format=markdown
- *   node compare.js --format=ascii
- *   node compare.js --format=both
- *   node compare.js --json
- *   node compare.js --quick   # shorter sampling windows for local smoke runs
- */
 
 import { writeFileSync, mkdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
@@ -123,7 +112,6 @@ if (args.json || args.out) {
   console.error(`\nWrote JSON report to ${outPath}`)
 }
 
-// Expose markdown for GitHub Actions step summaries via stdout marker
 if (process.env.GITHUB_STEP_SUMMARY) {
   writeFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`, { flag: 'a' })
 }

--- a/benchmarks/package-lock.json
+++ b/benchmarks/package-lock.json
@@ -20,7 +20,8 @@
         "zbsearch": "file:../packages/zbsearch"
       },
       "devDependencies": {
-        "benny": "^3.7.1"
+        "benny": "^3.7.1",
+        "esbuild": "^0.28.1"
       }
     },
     "../node_modules/.pnpm/@playwright+test@1.61.1/node_modules/@playwright/test": {
@@ -921,6 +922,448 @@
       "resolved": "../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript",
       "link": true
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@orama/orama": {
       "version": "3.1.18",
       "resolved": "https://registry.npmjs.org/@orama/orama/-/orama-3.1.18.tgz",
@@ -945,6 +1388,48 @@
     "node_modules/benny": {
       "resolved": "../node_modules/.pnpm/benny@3.7.1/node_modules/benny",
       "link": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/flexsearch": {
       "version": "0.8.212",

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -6,6 +6,8 @@
   "type": "module",
   "scripts": {
     "benchmark": "node index.js",
+    "benchmark:compare": "node compare.js --format=both --json",
+    "benchmark:compare:quick": "node compare.js --format=both --quick",
     "benchmark:algorithms": "node algorithms.js",
     "benchmark:bkd": "node bkd.js",
     "benchmark:avl": "node avl.js",
@@ -30,6 +32,7 @@
     "zbsearch": "file:../packages/zbsearch"
   },
   "devDependencies": {
-    "benny": "^3.7.1"
+    "benny": "^3.7.1",
+    "esbuild": "^0.28.1"
   }
 }

--- a/benchmarks/src/compare/geo-dataset.js
+++ b/benchmarks/src/compare/geo-dataset.js
@@ -1,0 +1,35 @@
+import dataset from '../dataset.json' with { type: 'json' }
+
+// San Francisco Bay Area bounding box (same region as bkd benchmarks)
+const MIN_LON = -122.55
+const MAX_LON = -122.35
+const MIN_LAT = 37.7
+const MAX_LAT = 37.85
+
+/**
+ * Deterministic pseudo-random so geo benchmarks are stable across runs.
+ */
+function hashIndex(i) {
+  let x = (i + 1) * 2654435761
+  x ^= x >>> 16
+  x = Math.imul(x, 2246822519)
+  x ^= x >>> 13
+  return (x >>> 0) / 0xffffffff
+}
+
+/**
+ * Attach a geopoint to each game record for geosearch benchmarks.
+ */
+export function withGeoPoints(records = dataset) {
+  return records.map((record, i) => ({
+    ...record,
+    location: {
+      lon: MIN_LON + hashIndex(i) * (MAX_LON - MIN_LON),
+      lat: MIN_LAT + hashIndex(i + 997) * (MAX_LAT - MIN_LAT)
+    }
+  }))
+}
+
+export const GEO_SEARCH_CENTER = { lon: -122.45, lat: 37.78 }
+
+export const GEO_RADIUS_KM = 3

--- a/benchmarks/src/compare/geo-dataset.js
+++ b/benchmarks/src/compare/geo-dataset.js
@@ -1,14 +1,10 @@
 import dataset from '../dataset.json' with { type: 'json' }
 
-// San Francisco Bay Area bounding box (same region as bkd benchmarks)
 const MIN_LON = -122.55
 const MAX_LON = -122.35
 const MIN_LAT = 37.7
 const MAX_LAT = 37.85
 
-/**
- * Deterministic pseudo-random so geo benchmarks are stable across runs.
- */
 function hashIndex(i) {
   let x = (i + 1) * 2654435761
   x ^= x >>> 16
@@ -17,9 +13,6 @@ function hashIndex(i) {
   return (x >>> 0) / 0xffffffff
 }
 
-/**
- * Attach a geopoint to each game record for geosearch benchmarks.
- */
 export function withGeoPoints(records = dataset) {
   return records.map((record, i) => ({
     ...record,

--- a/benchmarks/src/compare/suites.js
+++ b/benchmarks/src/compare/suites.js
@@ -1,0 +1,461 @@
+import { createRequire } from 'node:module'
+import { writeFileSync, mkdirSync, rmSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { gzipSync } from 'node:zlib'
+import { buildSync } from 'esbuild'
+import * as orama from '@orama/orama'
+import * as zbsearch from 'zbsearch'
+import dataset from '../dataset.json' with { type: 'json' }
+import {
+  SEARCH_LIMIT,
+  stopWordTokenizer,
+  databaseSortConfig,
+  PLAIN_SEARCH_TERM,
+  FILTER_SEARCH_TERM,
+  COMPLEX_SEARCH_TERM
+} from '../benchmark-config.js'
+import { withGeoPoints, GEO_SEARCH_CENTER, GEO_RADIUS_KM } from './geo-dataset.js'
+import { benchOps, benchTime } from './timer.js'
+import { measureEngineMemory } from '../measure-memory.mjs'
+
+const require = createRequire(import.meta.url)
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export const versions = {
+  orama: require('@orama/orama/package.json').version,
+  zbsearch: require('zbsearch/package.json').version
+}
+
+const schema = {
+  title: 'string',
+  description: 'string',
+  rating: 'number',
+  genres: 'enum[]'
+}
+
+const geoSchema = {
+  ...schema,
+  location: 'geopoint'
+}
+
+const geoDataset = withGeoPoints(dataset)
+
+const ratingRanges = {
+  ranges: [
+    { from: 0, to: 3 },
+    { from: 3, to: 4 },
+    { from: 4, to: 5 }
+  ]
+}
+
+function createDb(engine, { geo = false } = {}) {
+  const lib = engine === 'orama' ? orama : zbsearch
+  const options = {
+    schema: geo ? geoSchema : schema,
+    components: { tokenizer: stopWordTokenizer }
+  }
+
+  // Keep insert benchmarks fair: zbsearch enables sort indexes by default.
+  if (engine === 'zbsearch') {
+    options.sort = databaseSortConfig
+  }
+
+  return lib.create(options)
+}
+
+function populate(engine, db, records = dataset) {
+  const lib = engine === 'orama' ? orama : zbsearch
+  const ids = lib.insertMultiple(db, records, records.length)
+  return { db, ids }
+}
+
+function createPopulated(engine, options = {}) {
+  const records = options.geo ? geoDataset : dataset
+  return populate(engine, createDb(engine, options), records)
+}
+
+function installPin(engine, db, docId) {
+  const lib = engine === 'orama' ? orama : zbsearch
+  if (!docId || typeof lib.insertPin !== 'function') {
+    return false
+  }
+
+  lib.insertPin(db, {
+    id: 'bench_pin',
+    conditions: [{ anchoring: 'contains', pattern: 'zelda' }],
+    consequence: {
+      promote: [{ doc_id: docId, position: 0 }]
+    }
+  })
+  return true
+}
+
+/**
+ * Run all Orama vs ZBSearch suites and return raw numeric results.
+ */
+export function runComparisonSuites(options = {}) {
+  const opsDurationMs = options.opsDurationMs ?? 800
+  const opsWarmupMs = options.opsWarmupMs ?? 150
+  const indexIterations = options.indexIterations ?? 8
+
+  const results = []
+
+  // --- Indexing ---
+  const indexInsert = {
+    orama: benchTime(
+      () => {
+        const db = createDb('orama')
+        for (const record of dataset) {
+          orama.insert(db, record)
+        }
+      },
+      { iterations: indexIterations }
+    ),
+    zbsearch: benchTime(
+      () => {
+        const db = createDb('zbsearch')
+        for (const record of dataset) {
+          zbsearch.insert(db, record)
+        }
+      },
+      { iterations: indexIterations }
+    )
+  }
+
+  results.push({
+    category: 'Indexing',
+    name: 'Indexing (insert one-by-one)',
+    unit: 'ms',
+    higherIsBetter: false,
+    orama: indexInsert.orama.medianMs,
+    zbsearch: indexInsert.zbsearch.medianMs
+  })
+
+  const indexMultiple = {
+    orama: benchTime(
+      () => {
+        const db = createDb('orama')
+        orama.insertMultiple(db, dataset, dataset.length)
+      },
+      { iterations: indexIterations }
+    ),
+    zbsearch: benchTime(
+      () => {
+        const db = createDb('zbsearch')
+        zbsearch.insertMultiple(db, dataset, dataset.length)
+      },
+      { iterations: indexIterations }
+    )
+  }
+
+  results.push({
+    category: 'Indexing',
+    name: 'Indexing (insertMultiple)',
+    unit: 'ms',
+    higherIsBetter: false,
+    orama: indexMultiple.orama.medianMs,
+    zbsearch: indexMultiple.zbsearch.medianMs
+  })
+
+  // --- Search (shared populated DBs) ---
+  const { db: dbOrama } = createPopulated('orama')
+  const { db: dbZB } = createPopulated('zbsearch')
+
+  const searchCases = [
+    {
+      name: 'Prefix search (simple)',
+      params: { term: 'Zel', limit: SEARCH_LIMIT, threshold: 0 }
+    },
+    {
+      name: 'Exact match search',
+      params: { term: 'Elden', exact: true, limit: SEARCH_LIMIT }
+    },
+    {
+      name: 'Plain full-text search',
+      params: { term: PLAIN_SEARCH_TERM, limit: SEARCH_LIMIT, threshold: 0 }
+    },
+    {
+      name: 'Typo-tolerant search',
+      params: { term: 'Eldan Ring', tolerance: 1, limit: SEARCH_LIMIT }
+    },
+    {
+      name: 'Search with filters',
+      params: {
+        term: FILTER_SEARCH_TERM,
+        where: { rating: { gte: 4 } },
+        limit: SEARCH_LIMIT
+      }
+    },
+    {
+      name: 'Complex query + filters',
+      params: {
+        term: COMPLEX_SEARCH_TERM,
+        where: { rating: { gte: 4 }, genres: { containsAll: ['Shooter'] } },
+        limit: SEARCH_LIMIT
+      }
+    },
+    {
+      name: 'Search with facets',
+      params: {
+        term: 'adventure',
+        facets: { genres: {}, rating: ratingRanges },
+        limit: SEARCH_LIMIT
+      }
+    },
+    {
+      name: 'Facets + filters',
+      params: {
+        term: 'game',
+        where: { rating: { gte: 4 } },
+        facets: { genres: {}, rating: ratingRanges },
+        limit: SEARCH_LIMIT
+      }
+    },
+    {
+      name: 'Field boosting',
+      params: {
+        term: PLAIN_SEARCH_TERM,
+        boost: { title: 2, description: 0.5 },
+        limit: SEARCH_LIMIT
+      }
+    }
+  ]
+
+  for (const { name, params } of searchCases) {
+    const oramaResult = benchOps(() => orama.search(dbOrama, params), {
+      durationMs: opsDurationMs,
+      warmupMs: opsWarmupMs
+    })
+    const zbResult = benchOps(() => zbsearch.search(dbZB, params), {
+      durationMs: opsDurationMs,
+      warmupMs: opsWarmupMs
+    })
+
+    results.push({
+      category: 'Search',
+      name,
+      unit: 'ops',
+      higherIsBetter: true,
+      orama: oramaResult.opsPerSec,
+      zbsearch: zbResult.opsPerSec
+    })
+  }
+
+  // --- Pinning ---
+  const { db: dbOramaPin, ids: oramaPinIds } = createPopulated('orama')
+  const { db: dbZBPin, ids: zbPinIds } = createPopulated('zbsearch')
+  const oramaHasPin = installPin('orama', dbOramaPin, oramaPinIds[0])
+  const zbHasPin = installPin('zbsearch', dbZBPin, zbPinIds[0])
+
+  if (oramaHasPin && zbHasPin) {
+    const pinParams = { term: PLAIN_SEARCH_TERM, limit: SEARCH_LIMIT }
+    const oramaPin = benchOps(() => orama.search(dbOramaPin, pinParams), {
+      durationMs: opsDurationMs,
+      warmupMs: opsWarmupMs
+    })
+    const zbPin = benchOps(() => zbsearch.search(dbZBPin, pinParams), {
+      durationMs: opsDurationMs,
+      warmupMs: opsWarmupMs
+    })
+
+    results.push({
+      category: 'Search',
+      name: 'Search with results pinning',
+      unit: 'ops',
+      higherIsBetter: true,
+      orama: oramaPin.opsPerSec,
+      zbsearch: zbPin.opsPerSec
+    })
+  }
+
+  // --- Geosearch ---
+  const { db: dbOramaGeo } = createPopulated('orama', { geo: true })
+  const { db: dbZBGeo } = createPopulated('zbsearch', { geo: true })
+
+  const geoParams = {
+    term: '',
+    where: {
+      location: {
+        radius: {
+          coordinates: GEO_SEARCH_CENTER,
+          unit: 'km',
+          value: GEO_RADIUS_KM,
+          inside: true
+        }
+      }
+    },
+    limit: SEARCH_LIMIT
+  }
+
+  const geoFilteredParams = {
+    term: 'game',
+    where: {
+      rating: { gte: 4 },
+      location: {
+        radius: {
+          coordinates: GEO_SEARCH_CENTER,
+          unit: 'km',
+          value: GEO_RADIUS_KM,
+          inside: true
+        }
+      }
+    },
+    limit: SEARCH_LIMIT
+  }
+
+  for (const [name, params] of [
+    ['Geosearch (radius)', geoParams],
+    ['Geosearch + text + filters', geoFilteredParams]
+  ]) {
+    const oramaGeo = benchOps(() => orama.search(dbOramaGeo, params), {
+      durationMs: opsDurationMs,
+      warmupMs: opsWarmupMs
+    })
+    const zbGeo = benchOps(() => zbsearch.search(dbZBGeo, params), {
+      durationMs: opsDurationMs,
+      warmupMs: opsWarmupMs
+    })
+
+    results.push({
+      category: 'Geosearch',
+      name,
+      unit: 'ops',
+      higherIsBetter: true,
+      orama: oramaGeo.opsPerSec,
+      zbsearch: zbGeo.opsPerSec
+    })
+  }
+
+  // --- Remove throughput ---
+  const removeResult = {
+    orama: benchTime(
+      () => {
+        const { db, ids } = createPopulated('orama')
+        for (let i = 0; i < 100; i++) {
+          orama.remove(db, ids[i])
+        }
+      },
+      { iterations: 6 }
+    ),
+    zbsearch: benchTime(
+      () => {
+        const { db, ids } = createPopulated('zbsearch')
+        for (let i = 0; i < 100; i++) {
+          zbsearch.remove(db, ids[i])
+        }
+      },
+      { iterations: 6 }
+    )
+  }
+
+  results.push({
+    category: 'Mutations',
+    name: 'Remove 100 documents',
+    unit: 'ms',
+    higherIsBetter: false,
+    orama: removeResult.orama.medianMs,
+    zbsearch: removeResult.zbsearch.medianMs
+  })
+
+  // --- Memory ---
+  const memOrama = measureEngineMemory('orama', { searches: 50 })
+  const memZB = measureEngineMemory('zbsearch', { searches: 50 })
+
+  results.push({
+    category: 'Memory',
+    name: 'Memory footprint (heap delta)',
+    unit: 'bytes',
+    higherIsBetter: false,
+    orama: memOrama.indexedDelta.heapUsed,
+    zbsearch: memZB.indexedDelta.heapUsed
+  })
+
+  results.push({
+    category: 'Memory',
+    name: 'Memory footprint (RSS delta)',
+    unit: 'bytes',
+    higherIsBetter: false,
+    orama: memOrama.indexedDelta.rss,
+    zbsearch: memZB.indexedDelta.rss
+  })
+
+  results.push({
+    category: 'Memory',
+    name: 'Serialized index size (JSON)',
+    unit: 'bytes',
+    higherIsBetter: false,
+    orama: memOrama.serializedBytes,
+    zbsearch: memZB.serializedBytes
+  })
+
+  // --- Bundle / package size ---
+  const bundles = measurePackageBundles()
+  results.push({
+    category: 'Bundle',
+    name: 'JS bundle size (minified)',
+    unit: 'bytes',
+    higherIsBetter: false,
+    orama: bundles.orama.minified,
+    zbsearch: bundles.zbsearch.minified
+  })
+  results.push({
+    category: 'Bundle',
+    name: 'JS bundle size (min+gzip)',
+    unit: 'bytes',
+    higherIsBetter: false,
+    orama: bundles.orama.gzip,
+    zbsearch: bundles.zbsearch.gzip
+  })
+
+  return {
+    versions,
+    records: dataset.length,
+    results,
+    meta: {
+      node: process.version,
+      platform: `${process.platform}/${process.arch}`,
+      date: new Date().toISOString()
+    }
+  }
+}
+
+function measurePackageBundles() {
+  const outDir = join(__dirname, '../../.compare-bundle')
+  mkdirSync(outDir, { recursive: true })
+
+  const packages = [
+    { key: 'orama', entry: '@orama/orama' },
+    { key: 'zbsearch', entry: 'zbsearch' }
+  ]
+
+  const sizes = {}
+
+  for (const { key, entry } of packages) {
+    const outfile = join(outDir, `${key}.mjs`)
+    const source = `
+      import { create, insert, insertMultiple, search, remove, save, load } from '${entry}'
+      export { create, insert, insertMultiple, search, remove, save, load }
+    `
+    const entryFile = join(outDir, `${key}-entry.mjs`)
+    writeFileSync(entryFile, source)
+
+    buildSync({
+      entryPoints: [entryFile],
+      outfile,
+      bundle: true,
+      format: 'esm',
+      platform: 'neutral',
+      minify: true,
+      treeShaking: true,
+      logLevel: 'silent'
+    })
+
+    const minified = statSync(outfile).size
+    const gzip = gzipSync(readFileSync(outfile)).length
+    sizes[key] = { minified, gzip }
+  }
+
+  rmSync(outDir, { recursive: true, force: true })
+  return sizes
+}

--- a/benchmarks/src/compare/suites.js
+++ b/benchmarks/src/compare/suites.js
@@ -56,7 +56,6 @@ function createDb(engine, { geo = false } = {}) {
     components: { tokenizer: stopWordTokenizer }
   }
 
-  // Keep insert benchmarks fair: zbsearch enables sort indexes by default.
   if (engine === 'zbsearch') {
     options.sort = databaseSortConfig
   }
@@ -91,9 +90,6 @@ function installPin(engine, db, docId) {
   return true
 }
 
-/**
- * Run all Orama vs ZBSearch suites and return raw numeric results.
- */
 export function runComparisonSuites(options = {}) {
   const opsDurationMs = options.opsDurationMs ?? 800
   const opsWarmupMs = options.opsWarmupMs ?? 150
@@ -101,7 +97,6 @@ export function runComparisonSuites(options = {}) {
 
   const results = []
 
-  // --- Indexing ---
   const indexInsert = {
     orama: benchTime(
       () => {
@@ -158,7 +153,6 @@ export function runComparisonSuites(options = {}) {
     zbsearch: indexMultiple.zbsearch.medianMs
   })
 
-  // --- Search (shared populated DBs) ---
   const { db: dbOrama } = createPopulated('orama')
   const { db: dbZB } = createPopulated('zbsearch')
 
@@ -242,7 +236,6 @@ export function runComparisonSuites(options = {}) {
     })
   }
 
-  // --- Pinning ---
   const { db: dbOramaPin, ids: oramaPinIds } = createPopulated('orama')
   const { db: dbZBPin, ids: zbPinIds } = createPopulated('zbsearch')
   const oramaHasPin = installPin('orama', dbOramaPin, oramaPinIds[0])
@@ -269,7 +262,6 @@ export function runComparisonSuites(options = {}) {
     })
   }
 
-  // --- Geosearch ---
   const { db: dbOramaGeo } = createPopulated('orama', { geo: true })
   const { db: dbZBGeo } = createPopulated('zbsearch', { geo: true })
 
@@ -327,7 +319,6 @@ export function runComparisonSuites(options = {}) {
     })
   }
 
-  // --- Remove throughput ---
   const removeResult = {
     orama: benchTime(
       () => {
@@ -358,7 +349,6 @@ export function runComparisonSuites(options = {}) {
     zbsearch: removeResult.zbsearch.medianMs
   })
 
-  // --- Memory ---
   const memOrama = measureEngineMemory('orama', { searches: 50 })
   const memZB = measureEngineMemory('zbsearch', { searches: 50 })
 
@@ -389,7 +379,6 @@ export function runComparisonSuites(options = {}) {
     zbsearch: memZB.serializedBytes
   })
 
-  // --- Bundle / package size ---
   const bundles = measurePackageBundles()
   results.push({
     category: 'Bundle',

--- a/benchmarks/src/compare/table.js
+++ b/benchmarks/src/compare/table.js
@@ -1,7 +1,3 @@
-/**
- * Render comparison results as Markdown and ASCII tables.
- */
-
 function pad(value, width, align = 'left') {
   const text = String(value)
   if (text.length >= width) return text
@@ -30,9 +26,6 @@ function formatMs(ms) {
   return `${(ms / 1000).toFixed(2)} s`
 }
 
-/**
- * @param {{ name: string, unit: 'ops'|'bytes'|'ms', orama: number, zbsearch: number, higherIsBetter?: boolean }} row
- */
 export function compareRow(row) {
   const { name, unit, orama, zbsearch, higherIsBetter = unit === 'ops' } = row
   const format =
@@ -54,7 +47,6 @@ export function compareRow(row) {
       delta = `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%`
     } else {
       winner = zbsearch < orama ? 'ZBSearch' : 'Orama'
-      // For lower-is-better, show how much smaller/faster zbsearch is vs orama
       delta = `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%`
     }
   } else if (orama == null && zbsearch != null) {
@@ -76,10 +68,6 @@ export function compareRow(row) {
   }
 }
 
-/**
- * @param {ReturnType<typeof compareRow>[]} rows
- * @param {{ oramaVersion: string, zbsearchVersion: string, title?: string }} meta
- */
 export function toMarkdownTable(rows, meta) {
   const title = meta.title ?? 'Orama vs ZBSearch'
   const lines = [
@@ -100,10 +88,6 @@ export function toMarkdownTable(rows, meta) {
   return lines.join('\n')
 }
 
-/**
- * @param {ReturnType<typeof compareRow>[]} rows
- * @param {{ oramaVersion: string, zbsearchVersion: string, title?: string }} meta
- */
 export function toAsciiTable(rows, meta) {
   const headers = [
     'Metric',

--- a/benchmarks/src/compare/table.js
+++ b/benchmarks/src/compare/table.js
@@ -1,0 +1,150 @@
+/**
+ * Render comparison results as Markdown and ASCII tables.
+ */
+
+function pad(value, width, align = 'left') {
+  const text = String(value)
+  if (text.length >= width) return text
+  const padding = ' '.repeat(width - text.length)
+  return align === 'right' ? padding + text : text + padding
+}
+
+function formatOps(value) {
+  if (value == null || Number.isNaN(value)) return 'n/a'
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M/s`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(2)}k/s`
+  return `${value.toFixed(2)}/s`
+}
+
+function formatBytes(bytes) {
+  if (bytes == null || Number.isNaN(bytes)) return 'n/a'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
+function formatMs(ms) {
+  if (ms == null || Number.isNaN(ms)) return 'n/a'
+  if (ms < 1) return `${(ms * 1000).toFixed(1)} µs`
+  if (ms < 1000) return `${ms.toFixed(2)} ms`
+  return `${(ms / 1000).toFixed(2)} s`
+}
+
+/**
+ * @param {{ name: string, unit: 'ops'|'bytes'|'ms', orama: number, zbsearch: number, higherIsBetter?: boolean }} row
+ */
+export function compareRow(row) {
+  const { name, unit, orama, zbsearch, higherIsBetter = unit === 'ops' } = row
+  const format =
+    unit === 'ops' ? formatOps : unit === 'bytes' ? formatBytes : formatMs
+
+  let winner = 'tie'
+  let delta = '0%'
+
+  if (orama != null && zbsearch != null && orama !== 0 && zbsearch !== 0) {
+    const ratio = zbsearch / orama
+    const pct = (ratio - 1) * 100
+    const absPct = Math.abs(pct)
+
+    if (absPct < 1) {
+      winner = 'tie'
+      delta = `~${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%`
+    } else if (higherIsBetter) {
+      winner = zbsearch > orama ? 'ZBSearch' : 'Orama'
+      delta = `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%`
+    } else {
+      winner = zbsearch < orama ? 'ZBSearch' : 'Orama'
+      // For lower-is-better, show how much smaller/faster zbsearch is vs orama
+      delta = `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%`
+    }
+  } else if (orama == null && zbsearch != null) {
+    winner = 'ZBSearch'
+    delta = 'n/a'
+  } else if (zbsearch == null && orama != null) {
+    winner = 'Orama'
+    delta = 'n/a'
+  }
+
+  return {
+    metric: name,
+    orama: format(orama),
+    zbsearch: format(zbsearch),
+    winner,
+    delta,
+    unit,
+    raw: { orama, zbsearch }
+  }
+}
+
+/**
+ * @param {ReturnType<typeof compareRow>[]} rows
+ * @param {{ oramaVersion: string, zbsearchVersion: string, title?: string }} meta
+ */
+export function toMarkdownTable(rows, meta) {
+  const title = meta.title ?? 'Orama vs ZBSearch'
+  const lines = [
+    `## ${title}`,
+    '',
+    `Orama **${meta.oramaVersion}** vs ZBSearch **${meta.zbsearchVersion}**`,
+    '',
+    `| Metric | Orama ${meta.oramaVersion} | ZBSearch ${meta.zbsearchVersion} | Winner | Δ (ZB / Orama) |`,
+    `| --- | ---: | ---: | --- | ---: |`
+  ]
+
+  for (const row of rows) {
+    lines.push(
+      `| ${row.metric} | ${row.orama} | ${row.zbsearch} | ${row.winner} | ${row.delta} |`
+    )
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * @param {ReturnType<typeof compareRow>[]} rows
+ * @param {{ oramaVersion: string, zbsearchVersion: string, title?: string }} meta
+ */
+export function toAsciiTable(rows, meta) {
+  const headers = [
+    'Metric',
+    `Orama ${meta.oramaVersion}`,
+    `ZBSearch ${meta.zbsearchVersion}`,
+    'Winner',
+    'Δ (ZB/Orama)'
+  ]
+  const data = rows.map((row) => [
+    row.metric,
+    row.orama,
+    row.zbsearch,
+    row.winner,
+    row.delta
+  ])
+
+  const widths = headers.map((header, i) =>
+    Math.max(header.length, ...data.map((row) => String(row[i]).length))
+  )
+
+  const rule = `+-${widths.map((w) => '-'.repeat(w)).join('-+-')}-+`
+  const formatLine = (cells, aligns) =>
+    `| ${cells.map((cell, i) => pad(cell, widths[i], aligns[i])).join(' | ')} |`
+
+  const aligns = ['left', 'right', 'right', 'left', 'right']
+  const lines = [
+    meta.title ?? 'Orama vs ZBSearch',
+    rule,
+    formatLine(headers, aligns),
+    rule,
+    ...data.map((row) => formatLine(row, aligns)),
+    rule
+  ]
+
+  return lines.join('\n')
+}
+
+export function summarizeWinners(rows) {
+  const counts = { Orama: 0, ZBSearch: 0, tie: 0 }
+  for (const row of rows) {
+    counts[row.winner] = (counts[row.winner] ?? 0) + 1
+  }
+  return counts
+}

--- a/benchmarks/src/compare/timer.js
+++ b/benchmarks/src/compare/timer.js
@@ -1,0 +1,74 @@
+/**
+ * Lightweight micro-benchmark helpers for CI-friendly comparisons.
+ * Prefer duration-based sampling for fast ops; fixed iterations for slow ones.
+ */
+
+export function median(values) {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+export function mean(values) {
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+/**
+ * @param {() => void} fn
+ * @param {{ durationMs?: number, warmupMs?: number }} [options]
+ */
+export function benchOps(fn, options = {}) {
+  const { durationMs = 800, warmupMs = 150 } = options
+
+  const warmupEnd = performance.now() + warmupMs
+  while (performance.now() < warmupEnd) {
+    fn()
+  }
+
+  let iterations = 0
+  const start = performance.now()
+  const end = start + durationMs
+  while (performance.now() < end) {
+    fn()
+    iterations++
+  }
+  const elapsedMs = performance.now() - start
+
+  return {
+    kind: 'ops',
+    iterations,
+    elapsedMs,
+    opsPerSec: (iterations / elapsedMs) * 1000,
+    msPerOp: elapsedMs / iterations
+  }
+}
+
+/**
+ * @param {() => void} fn
+ * @param {{ iterations?: number, warmup?: number }} [options]
+ */
+export function benchTime(fn, options = {}) {
+  const { iterations = 12, warmup = 2 } = options
+
+  for (let i = 0; i < warmup; i++) {
+    fn()
+  }
+
+  const samples = []
+  for (let i = 0; i < iterations; i++) {
+    const start = performance.now()
+    fn()
+    samples.push(performance.now() - start)
+  }
+
+  const medianMs = median(samples)
+  return {
+    kind: 'time',
+    iterations,
+    samples,
+    medianMs,
+    meanMs: mean(samples),
+    opsPerSec: 1000 / medianMs,
+    msPerOp: medianMs
+  }
+}

--- a/benchmarks/src/compare/timer.js
+++ b/benchmarks/src/compare/timer.js
@@ -1,8 +1,3 @@
-/**
- * Lightweight micro-benchmark helpers for CI-friendly comparisons.
- * Prefer duration-based sampling for fast ops; fixed iterations for slow ones.
- */
-
 export function median(values) {
   const sorted = [...values].sort((a, b) => a - b)
   const mid = Math.floor(sorted.length / 2)
@@ -13,10 +8,6 @@ export function mean(values) {
   return values.reduce((sum, value) => sum + value, 0) / values.length
 }
 
-/**
- * @param {() => void} fn
- * @param {{ durationMs?: number, warmupMs?: number }} [options]
- */
 export function benchOps(fn, options = {}) {
   const { durationMs = 800, warmupMs = 150 } = options
 
@@ -43,10 +34,6 @@ export function benchOps(fn, options = {}) {
   }
 }
 
-/**
- * @param {() => void} fn
- * @param {{ iterations?: number, warmup?: number }} [options]
- */
 export function benchTime(fn, options = {}) {
   const { iterations = 12, warmup = 2 } = options
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a head-to-head **Orama (latest npm) vs ZBSearch (local build)** benchmark suite and a `workflow_dispatch` GitHub Action that prints Markdown/ASCII result tables.

### Metrics covered
- Indexing speed (`insert` + `insertMultiple`)
- Prefix, exact match, plain full-text, and typo-tolerant search
- Filters, complex queries, facets, field boosting, results pinning
- Geosearch (radius + combined text/filters)
- Document removal throughput
- Memory footprint (heap/RSS) and serialized index size
- Minified + gzip JS bundle size

### How to run locally
```sh
pnpm --filter zbsearch build
pnpm --filter @zbsearch/stopwords build
cd benchmarks && npm install
npm run benchmark:compare
```

### GitHub Actions
**Actions → Orama vs ZBSearch Benchmarks → Run workflow**

Outputs:
- Markdown table in the job summary
- ASCII/Markdown table in the job log
- JSON artifact `orama-vs-zbsearch-benchmarks`

Also includes a short `benchmarks/README.md` documenting the new and existing suites.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bd6530f-160c-45d2-94e5-868ea84d9a72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bd6530f-160c-45d2-94e5-868ea84d9a72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

