### PR TITLE
Fix hybrid search scoring and weight handling

### DIFF
--- a/packages/zbsearch/src/methods/search-fulltext.ts
+++ b/packages/zbsearch/src/methods/search-fulltext.ts
@@ -26,7 +26,8 @@ export function innerFullTextSearch<T extends AnyZBSearch>(
     SearchParamsFullText<T>,
     'term' | 'properties' | 'where' | 'exact' | 'tolerance' | 'boost' | 'relevance' | 'threshold'
   >,
-  language: Language | undefined
+  language: Language | undefined,
+  precomputedWhereFiltersIDs?: Set<number>
 ) {
   const { term, properties } = params
 
@@ -56,8 +57,9 @@ export function innerFullTextSearch<T extends AnyZBSearch>(
 
   // If filters are enabled, we need to get the IDs of the documents that match the filters.
   const hasFilters = Object.keys(params.where ?? {}).length > 0
-  let whereFiltersIDs: Set<number> | undefined
-  if (hasFilters) {
+  let whereFiltersIDs: Set<number> | undefined = precomputedWhereFiltersIDs
+
+  if (hasFilters && whereFiltersIDs === undefined) {
     whereFiltersIDs = zbsearch.index.searchByWhereClause(index, zbsearch.tokenizer, params.where!, language)
   }
 

--- a/packages/zbsearch/src/methods/search-hybrid.ts
+++ b/packages/zbsearch/src/methods/search-hybrid.ts
@@ -7,7 +7,8 @@ import type {
   Result,
   HybridWeights
 } from '../types.js'
-import { getNanosecondsTime, formatNanoseconds, removeVectorsFromHits } from '../utils.js'
+import type { InternalDocumentID } from '../components/internal-document-id-store.js'
+import { getNanosecondsTime, formatNanoseconds, removeVectorsFromHits, sortTokenScorePredicate } from '../utils.js'
 import { getFacets } from '../components/facets.js'
 import { getGroups } from '../components/groups.js'
 import { fetchDocuments } from './fetch-documents.js'
@@ -21,8 +22,17 @@ export function innerHybridSearch<T extends AnyZBSearch, ResultDocument = TypedD
   params: SearchParamsHybrid<T, ResultDocument>,
   language?: string
 ) {
-  const fullTextIDs = innerFullTextSearch(zbsearch, params, language)
-  const vectorIDs = innerVectorSearch(zbsearch, params, language)
+
+  const hasFilters = Object.keys(params.where ?? {}).length > 0
+  let whereFiltersIDs: Set<InternalDocumentID> | undefined
+
+  if (hasFilters) {
+    whereFiltersIDs = zbsearch.index.searchByWhereClause(zbsearch.data.index, zbsearch.tokenizer, params.where!, language)
+  }
+
+  const hasFullTextInput = Boolean(params.term) || Boolean(params.properties)
+  const fullTextIDs = hasFullTextInput ? innerFullTextSearch(zbsearch, params, language, whereFiltersIDs) : []
+  const vectorIDs = innerVectorSearch(zbsearch, params, language, whereFiltersIDs)
 
   const hybridWeights = params.hybridWeights
   return mergeAndRankResults(fullTextIDs, vectorIDs, params.term ?? '', hybridWeights)
@@ -102,12 +112,23 @@ export function hybridSearch<T extends AnyZBSearch, ResultDocument = TypedDocume
   return performSearchLogic()
 }
 
-function extractScore(token: TokenScore) {
-  return token[1]
+function getMaxScore(results: TokenScore[]) {
+  let max = 0
+  const resultsLength = results.length
+
+  for (let i = 0; i < resultsLength; i++) {
+    const score = results[i][1]
+
+    if (score > max) {
+      max = score
+    }
+  }
+
+  return max
 }
 
 function normalizeScore(score: number, maxScore: number) {
-  return score / maxScore
+  return maxScore > 0 ? score / maxScore : 0
 }
 
 function hybridScoreBuilder(textWeight: number, vectorWeight: number) {
@@ -119,13 +140,15 @@ function mergeAndRankResults(
   vectorResults: TokenScore[],
   query: string,
   hybridWeights: HybridWeights | undefined
-) {
-  const maxTextScore = Math.max(...textResults.map(extractScore))
-  const maxVectorScore = Math.max(...vectorResults.map(extractScore))
-  const hasHybridWeights = hybridWeights && hybridWeights.text && hybridWeights.vector
+): TokenScore[] {
+  // Avoid Math.max(...results): spreading large result sets overflows the call stack.
+  const maxTextScore = getMaxScore(textResults)
+  const maxVectorScore = getMaxScore(vectorResults)
+  const hasHybridWeights =
+    hybridWeights && typeof hybridWeights.text === 'number' && typeof hybridWeights.vector === 'number'
 
   const { text: textWeight, vector: vectorWeight } = hasHybridWeights ? hybridWeights : getQueryWeights(query)
-  const mergedResults = new Map()
+  const mergedResults = new Map<InternalDocumentID, number>()
 
   const textResultsLength = textResults.length
   const hybridScore = hybridScoreBuilder(textWeight, vectorWeight)
@@ -144,7 +167,7 @@ function mergeAndRankResults(
     mergedResults.set(resultId, existingRes + hybridScore(0, normalizedScore))
   }
 
-  return [...mergedResults].sort((a, b) => b[1] - a[1])
+  return [...mergedResults].sort(sortTokenScorePredicate) as TokenScore[]
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/zbsearch/src/methods/search-vector.ts
+++ b/packages/zbsearch/src/methods/search-vector.ts
@@ -13,7 +13,8 @@ import { fetchDocuments } from './fetch-documents.js'
 export function innerVectorSearch<T extends AnyZBSearch, ResultDocument = TypedDocument<T>>(
   zbsearch: T,
   params: Pick<SearchParamsVector<T, ResultDocument>, 'vector' | 'similarity' | 'where'>,
-  language: Language | undefined
+  language: Language | undefined,
+  precomputedWhereFiltersIDs?: Set<InternalDocumentID>
 ) {
   const vector = params.vector
 
@@ -36,9 +37,10 @@ export function innerVectorSearch<T extends AnyZBSearch, ResultDocument = TypedD
   }
 
   const index = zbsearch.data.index
-  let whereFiltersIDs: Set<InternalDocumentID> | undefined
+  let whereFiltersIDs: Set<InternalDocumentID> | undefined = precomputedWhereFiltersIDs
   const hasFilters = Object.keys(params.where ?? {}).length > 0
-  if (hasFilters) {
+
+  if (hasFilters && whereFiltersIDs === undefined) {
     whereFiltersIDs = zbsearch.index.searchByWhereClause(index, zbsearch.tokenizer, params.where!, language)
   }
 

--- a/packages/zbsearch/tests/search.hybrid.test.ts
+++ b/packages/zbsearch/tests/search.hybrid.test.ts
@@ -193,8 +193,78 @@ t.test('hybrid search', async (t) => {
     })
 
     t.equal(results.count, 2)
+    t.equal(results.hits[0].score, 1)
+    t.equal(results.hits[1].score, 1)
+  })
+
+  t.test('should work without a term (vector-only input)', async (t) => {
+    const db = await create({
+      schema: {
+        text: 'string',
+        embedding: 'vector[5]',
+        number: 'number'
+      } as const
+    })
+
+    await insertMultiple(db, [
+      { text: 'hello world', embedding: [1, 2, 3, 4, 5], number: 1 },
+      { text: 'hello there', embedding: [1, 2, 3, 4, 4], number: 2 },
+      { text: 'foo bar', embedding: [9, 9, 9, 9, 9], number: 3 }
+    ])
+
+    const results = await search(db, {
+      mode: 'hybrid',
+      vector: {
+        value: [1, 2, 3, 4, 5],
+        property: 'embedding'
+      },
+      similarity: 0.95
+    })
+
+    t.equal(results.count, 2)
+    for (const hit of results.hits) {
+      t.ok(Number.isFinite(hit.score), 'score should never be NaN')
+    }
+    // Pure vector contribution: 0.5 * normalized similarity
     t.equal(results.hits[0].score, 0.5)
-    t.equal(results.hits[1].score, 0.5)
+    t.equal(results.hits[0].document.number, 1)
+  })
+
+  t.test('should honor a zero weight in hybridWeights', async (t) => {
+    const db = await create({
+      schema: {
+        text: 'string',
+        embedding: 'vector[5]',
+        number: 'number'
+      } as const
+    })
+
+    await insertMultiple(db, [
+      { text: 'hello world', embedding: [1, 2, 3, 4, 5], number: 1 },
+      { text: 'hello there', embedding: [1, 2, 3, 4, 4], number: 2 },
+      { text: 'foo bar', embedding: [9, 9, 9, 9, 9], number: 3 }
+    ])
+
+    const results = await search(db, {
+      mode: 'hybrid',
+      term: 'hello',
+      vector: {
+        value: [1, 2, 3, 4, 5],
+        property: 'embedding'
+      },
+      similarity: 0.9,
+      hybridWeights: {
+        text: 0, // ignore full-text scores entirely
+        vector: 1
+      }
+    })
+
+    // The best vector match ranks first with its normalized similarity as the score
+    t.equal(results.hits[0].document.number, 1)
+    t.equal(results.hits[0].score, 1)
+    for (const hit of results.hits) {
+      t.ok(Number.isFinite(hit.score), 'score should never be NaN')
+    }
   })
 })
 


### PR DESCRIPTION
- prevent NaN scores when the full-text max score is 0 (e.g. hybrid queries without a term), which also produced undefined sort order
- honor zero values in hybridWeights instead of falling back to the default 0.5/0.5 weights
- replace Math.max(...spread) with a loop to avoid stack overflows on large result sets
- evaluate the where clause once and share filter IDs between the full-text and vector sub-searches
- skip the full-text scan entirely when no term/properties are given
- sort merged results with sortTokenScorePredicate for deterministic, ID-based tie-breaking consistent with other search modes