### PR TITLE
Fix skipped tests and repair removeMultiple/insertMultiple semantics

### DIFF
--- a/packages/zbsearch/src/methods/insert.ts
+++ b/packages/zbsearch/src/methods/insert.ts
@@ -485,20 +485,17 @@ function innerInsertMultipleSync<T extends AnyZBSearch>(
   }
 
   function processAllBatches() {
-    const startTime = Date.now()
-
     // eslint-disable-next-line no-constant-condition
     while (true) {
+      const startTime = Date.now()
       const hasMoreBatches = processNextBatch()
       if (!hasMoreBatches) break
 
       if (timeout > 0) {
         const elapsedTime = Date.now() - startTime
-        if (elapsedTime >= timeout) {
-          const remainingTime = timeout - (elapsedTime % timeout)
-          if (remainingTime > 0) {
-            sleep(remainingTime)
-          }
+        const waitTime = timeout - elapsedTime
+        if (waitTime > 0) {
+          sleep(waitTime)
         }
       }
     }

--- a/packages/zbsearch/src/methods/remove.ts
+++ b/packages/zbsearch/src/methods/remove.ts
@@ -316,22 +316,15 @@ function removeMultipleSync<T extends AnyZBSearch>(
     runMultipleHook(zbsearch.beforeRemoveMultiple, zbsearch, docIdsForHooks)
   }
 
-  let i = 0
-  function _removeMultipleSync() {
-    const batch = ids.slice(i * batchSize!, ++i * batchSize!)
-
-    if (!batch.length) return
+  for (let i = 0; i < ids.length; i += batchSize) {
+    const batch = ids.slice(i, i + batchSize)
 
     for (const doc of batch) {
       if (remove(zbsearch, doc, language, skipHooks)) {
         result++
       }
     }
-
-    setTimeout(_removeMultipleSync, 0)
   }
-
-  _removeMultipleSync()
 
   if (!skipHooks) {
     runMultipleHook(zbsearch.afterRemoveMultiple, zbsearch, docIdsForHooks)

--- a/packages/zbsearch/tests/customize.component.test.ts
+++ b/packages/zbsearch/tests/customize.component.test.ts
@@ -5,7 +5,7 @@ import {
   sorter as defaultSorter
 } from '../src/components.js'
 import { DocumentsStore } from '../src/components/documents-store.js'
-import { DocumentID, InternalDocumentIDStore } from '../src/components/internal-document-id-store.js'
+import { DocumentID, InternalDocumentID, InternalDocumentIDStore } from '../src/components/internal-document-id-store.js'
 import { Sorter } from '../src/components/sorter.js'
 import {
   AnyDocument,
@@ -15,6 +15,7 @@ import {
   IDocumentsStore,
   ISorter,
   SyncOrAsyncValue,
+  count,
   create,
   insert,
   load,
@@ -40,10 +41,17 @@ t.test('index', (t) => {
       }
     })
     const id = insert(db, { number: 1 }) as string
-    await search(db, { sortBy: { property: 'number' } })
+    t.equal(count(db), 1)
+
+    const result = await search(db, { sortBy: { property: 'number' } })
+    t.equal(result.count, 1)
+
     await remove(db, id)
+    t.equal(count(db), 0)
+
     const raw = await save(db)
     await load(db, raw)
+    t.equal(count(db), 0)
 
     t.end()
   })
@@ -79,8 +87,8 @@ t.test('documentStore', (t) => {
       getAll(s) {
         return store.getAll(s)
       },
-      store(s, id, doc) {
-        return store.store(s, id, doc)
+      store(s, id, internalId, doc) {
+        return store.store(s, id, internalId, doc)
       }
     }
     const db = create({
@@ -92,10 +100,17 @@ t.test('documentStore', (t) => {
       }
     })
     const id = insert(db, { number: 1 }) as string
-    await search(db, { sortBy: { property: 'number' } })
+    t.equal(count(db), 1)
+
+    const result = await search(db, { sortBy: { property: 'number' } })
+    t.equal(result.count, 1)
+
     await remove(db, id)
+    t.equal(count(db), 0)
+
     const raw = await save(db)
     await load(db, raw)
+    t.equal(count(db), 0)
 
     t.end()
   })
@@ -117,10 +132,17 @@ t.test('documentStore', (t) => {
       }
     })
     const id = await insert(db, { number: 1 })
-    await search(db, { sortBy: { property: 'number' } })
+    t.equal(count(db), 1)
+
+    const result = await search(db, { sortBy: { property: 'number' } })
+    t.equal(result.count, 1)
+
     await remove(db, id)
+    t.equal(count(db), 0)
+
     const raw = await save(db)
     await load(db, raw)
+    t.equal(count(db), 0)
 
     t.end()
   })
@@ -261,10 +283,17 @@ t.test('sorter', (t) => {
       }
     })
     const id = await insert(db, { number: 1 })
-    await search(db, { sortBy: { property: 'number' } })
+    t.equal(count(db), 1)
+
+    const result = await search(db, { sortBy: { property: 'number' } })
+    t.equal(result.count, 1)
+
     await remove(db, id)
+    t.equal(count(db), 0)
+
     const raw = await save(db)
     await load(db, raw)
+    t.equal(count(db), 0)
 
     t.end()
   })
@@ -296,8 +325,8 @@ t.test('sorter', (t) => {
       getAll(store: DocStorage): SyncOrAsyncValue<Record<number, any>> {
         return this.doc.getAll(store.storage)
       }
-      store(store: DocStorage, id: DocumentID, doc: AnyDocument): boolean {
-        return this.doc.store(store.storage, id, doc)
+      store(store: DocStorage, id: DocumentID, internalId: InternalDocumentID, doc: AnyDocument): boolean {
+        return this.doc.store(store.storage, id, internalId, doc)
       }
       remove(store: DocStorage, id: DocumentID): SyncOrAsyncValue<boolean> {
         return this.doc.remove(store.storage, id)
@@ -305,8 +334,8 @@ t.test('sorter', (t) => {
       count(store: DocStorage): number {
         return this.doc.count(store.storage)
       }
-      async load<R = unknown>(sharedInternalDocumentStore: InternalDocumentIDStore, raw: R): Promise<DocStorage> {
-        const originalDoc = await this.doc.load(sharedInternalDocumentStore, raw)
+      load<R = unknown>(sharedInternalDocumentStore: InternalDocumentIDStore, raw: R): DocStorage {
+        const originalDoc = this.doc.load(sharedInternalDocumentStore, raw)
 
         return {
           storage: originalDoc,
@@ -329,10 +358,17 @@ t.test('sorter', (t) => {
       }
     })
     const id = await insert(db, { number: 1 })
-    await search(db, { sortBy: { property: 'number' } })
+    t.equal(count(db), 1)
+
+    const result = await search(db, { sortBy: { property: 'number' } })
+    t.equal(result.count, 1)
+
     await remove(db, id)
+    t.equal(count(db), 0)
+
     const raw = await save(db)
     await load(db, raw)
+    t.equal(count(db), 0)
 
     t.end()
   })

--- a/packages/zbsearch/tests/insert.test.ts
+++ b/packages/zbsearch/tests/insert.test.ts
@@ -268,6 +268,8 @@ t.test('insert method', async (t) => {
       insert(db, { name: 'bar' })
       insert(db, { inner: {} })
 
+      t.equal(count(db), 4)
+
       t.end()
     })
 
@@ -479,8 +481,7 @@ t.test('insertMultiple method', async (t) => {
     }
   })
 
-  // Skipping this test for now, as it is not reliable
-  t.skip('should support `timeout` parameter', async (t) => {
+  t.test('should support `timeout` parameter', async (t) => {
     const db = create({
       schema: {
         description: 'string'
@@ -488,20 +489,19 @@ t.test('insertMultiple method', async (t) => {
     })
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const docs = (dataset as DataSet).result.events.slice(0, 1000)
+    const docs = (dataset as DataSet).result.events.slice(0, 10)
 
-    const batchSize = 10
+    const batchSize = 1
+    const timeout = 50
 
     const before = Date.now()
-    insertMultiple(db, docs, batchSize, undefined, false, 200)
+    insertMultiple(db, docs, batchSize, undefined, false, timeout)
     const after = Date.now()
 
-    t.equal(count(db), 1000)
+    t.equal(count(db), docs.length)
     const batchNumber = Math.ceil(docs.length / batchSize)
-    // the "sleep" is yeilded between batches,
-    // so it is not fired for the last batch
-    const expectedTime = (batchNumber - 1) * 20
-    t.equal(after - before > expectedTime, true)
+    const expectedTime = (batchNumber - 1) * timeout
+    t.equal(after - before >= expectedTime, true)
   })
 
   t.test('should correctly rebalance AVL tree once the threshold is reached', async (t) => {

--- a/packages/zbsearch/tests/remove.test.ts
+++ b/packages/zbsearch/tests/remove.test.ts
@@ -183,7 +183,10 @@ t.test('remove method', (t) => {
     const [db] = await createSimpleDB()
     const id5 = await insert(db, {})
 
-    await remove(db, id5)
+    const removed = await remove(db, id5)
+
+    t.ok(removed)
+    t.equal(count(db), 4)
 
     t.end()
   })
@@ -205,20 +208,50 @@ t.test('removeMultiple method', (t) => {
     t.end()
   })
 
-  // @todo: make sure sync methods do not block the event loop too.
-  t.skip('should run event loop every batch', async (t) => {
+  t.test('should remove all the given items synchronously even in multiple batches', (t) => {
     const [db, id1, id2, id3, id4] = createSimpleDB()
 
-    let count = 0
+    const removed = removeMultiple(db, [id1, id2, id3, id4], 2) as number
+
+    t.equal(removed, 4)
+    t.equal(count(db), 0)
+
+    t.end()
+  })
+
+  t.test('should run event loop every batch', async (t) => {
+    const db = create({
+      schema: {
+        name: 'string'
+      } as const,
+      plugins: [
+        {
+          name: 'force-async',
+          afterRemoveMultiple: async () => {}
+        }
+      ]
+    })
+
+    const ids = [
+      insert(db, { name: 'super coffee maker' }),
+      insert(db, { name: 'washing machine' }),
+      insert(db, { name: 'coffee maker' }),
+      insert(db, { name: 'dish washer' })
+    ] as string[]
+
+    let ticks = 0
     const intervalId = setInterval(() => {
-      count++
+      ticks++
     }, 0)
 
-    removeMultiple(db, [id1, id2, id3, id4], 1)
+    const removed = await removeMultiple(db, ids, 1)
 
     clearInterval(intervalId)
 
-    t.equal(count, 5)
+    t.equal(removed, ids.length)
+    t.equal(count(db), 0)
+    // the event loop turns at least once per batch
+    t.ok(ticks >= ids.length)
 
     t.end()
   })

--- a/packages/zbsearch/tests/utils.test.ts
+++ b/packages/zbsearch/tests/utils.test.ts
@@ -105,9 +105,7 @@ t.test('utils', async (t) => {
     t.equal(flattened['nested.nested2.nested3.bar'], 'baz')
   })
 
-  // This test is skipped because the implementation of isAsyncFunction is temporary and will be
-  // removed in a future version of ZBSearch.
-  t.skip('should correctly detect an async function', (t) => {
+  t.test('should correctly detect an async function', async (t) => {
     async function asyncFunction() {
       return 'async'
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core bulk insert/remove behavior (sync completion and timeout timing); async `removeMultiple` is unchanged but sync callers may see different timing and guaranteed full batch completion.
> 
> **Overview**
> **Sync `removeMultiple`** no longer schedules work with `setTimeout`; it processes every batch in a plain loop before returning, so callers get the full removal count and an empty store in one synchronous call.
> 
> **Sync `insertMultiple` `timeout`** now measures elapsed time **per batch** (timer reset each iteration) and sleeps `timeout - elapsedTime` when positive, replacing the previous whole-run timer and modulo-based wait logic.
> 
> Tests were updated to match: custom document store `store(..., internalId, doc)` signatures, stronger `count`/`search` assertions on customize flows, a dedicated sync multi-batch `removeMultiple` case, a rewritten `insertMultiple` timeout test (smaller batches/docs), async `removeMultiple` event-loop coverage via a `force-async` plugin, and re-enabled `isAsyncFunction` coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba61e7290def4abe152a70f7e9d235799354ee68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->