### PR TITLE
Adds support for schemaless instance creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,28 @@ ZBSearch currently supports 10 different data types:
 | `enum[]`         | An array of enums.                                                          | `['comedy', 'action', 'romance']`                                           |
 | `vector[<size>]` | A vector of numbers to perform vector search on.                            | `[0.403, 0.192, 0.830]`                                                     |
 
+## Schema inference (optional schema)
+
+The schema is optional. If you omit it, ZBSearch infers the type of every document property on first sight and indexes it on the fly:
+
+```js
+const db = create()
+
+insert(db, { name: 'Noise cancelling headphones', price: 99.99, meta: { rating: 4.5 } })
+// db.schema is now: { name: 'string', price: 'number', meta: { rating: 'number' } }
+```
+
+Types lock on first sight (a later conflicting value is rejected with `SCHEMA_VALIDATION_FAILURE`), and objects shaped like `{ lat, lon }` are inferred as `geopoint`. Vectors are the only types that are never inferred - a `number[]` is indistinguishable from an embedding — so embedding properties must still be declared, and they can be the only thing you declare:
+
+```js
+const db = create({
+  schema: { embedding: 'vector[1536]' },
+  inferSchema: true, // a provided schema is strict by default; this opts undeclared fields into inference
+})
+```
+
+Passing a schema keeps the classic strict behavior (undeclared fields are stored but not indexed). See the [official docs](https://zbsearch.dev) for the full inference rules.
+
 # Vector and Hybrid Search Support
 
 ZBSearch supports both vector and hybrid search by just setting `mode: 'vector'` when performing search.

--- a/apps/docs/content/docs/zbsearch/usage/create.mdx
+++ b/apps/docs/content/docs/zbsearch/usage/create.mdx
@@ -55,6 +55,48 @@ const movieDB = create({
 });
 ```
 
+## Schema-less usage (schema inference)
+
+The `schema` is **optional**. If you omit it, ZBSearch infers the type of every document property the first time it sees it, and indexes it on the fly:
+
+```javascript copy
+import { create, insert, search } from "zbsearch";
+
+const db = create();
+
+await insert(db, { title: "The Godfather", year: 1972, cast: { director: "Coppola" } });
+
+// db.schema is now: { title: "string", year: "number", cast: { director: "string" } }
+await search(db, { term: "godfather" });
+```
+
+Inferred types follow these rules:
+
+| Document value                          | Inferred type                              |
+| --------------------------------------- | ------------------------------------------ |
+| `string`                                | `string`                                   |
+| `number`                                | `number`                                   |
+| `boolean`                               | `boolean`                                  |
+| `string[]` / `number[]` / `boolean[]`   | `string[]` / `number[]` / `boolean[]`      |
+| `{ lat: number, lon: number }`          | `geopoint`                                 |
+| nested object                           | recursively inferred as nested properties  |
+| empty array, `null`, `undefined`        | deferred until a concrete value appears    |
+
+A few things worth knowing:
+
+- **Types lock on first sight.** If `year` is first seen as a `number`, a later document with `year: "1972"` is rejected with a `SCHEMA_VALIDATION_FAILURE` error, exactly as with a declared schema.
+- **Vectors are never inferred**, because a `number[]` is indistinguishable from an embedding. Declare vector (embedding) properties explicitly and let everything else be inferred:
+
+```javascript copy
+const db = create({
+  schema: { embedding: "vector[384]" },
+  inferSchema: true, // required: a provided schema is strict by default
+});
+```
+
+- **Providing a schema keeps the strict behavior**: properties not declared in the schema are stored but not indexed, unless you opt into inference with `inferSchema: true` as above. Conversely, `create({ inferSchema: false })` stores documents without indexing anything.
+- Inferred schemas are preserved by `save`/`load`, so schema-less databases survive persistence round-trips.
+
 ## Nested properties
 
 ZBSearch supports nested properties natively. Just add them as you would typically do in any JavaScript object:

--- a/packages/edge-core/src/service.ts
+++ b/packages/edge-core/src/service.ts
@@ -1,20 +1,19 @@
-import { create, insertMultiple, load, save, search, type AnySchema, type AnyZBSearch } from 'zbsearch'
-import { encode, decode } from '@msgpack/msgpack'
+import { decode, encode } from '@msgpack/msgpack'
+import { type AnySchema, type AnyZBSearch, create, insertMultiple, load, save, search } from 'zbsearch'
 
 import {
-  applyBufferOps,
   appendBufferOp,
   appendWalBatch,
+  applyBufferOps,
   clearBuffer,
   finalizeBufferAfterRebuild,
   freezeBufferForRebuild,
   readBufferOps
 } from './buffer.js'
-import { badRequest, notFound } from './errors.js'
 import type { WalCoordinator } from './coordinator.js'
-import { getIndexMeta, registerIndex, saveIndexMeta } from './registry.js'
+import { badRequest, notFound } from './errors.js'
 import { indexMetaKey, newVersionId, snapshotKey } from './paths.js'
-import { isShardGroupMeta, shardIndexId } from './shards.js'
+import { getIndexMeta, registerIndex, saveIndexMeta } from './registry.js'
 import {
   bufferBatchSharded,
   bufferDeleteSharded,
@@ -25,18 +24,13 @@ import {
   rebuildShardGroup,
   runShardedSearch
 } from './shard-group.js'
+import { isShardGroupMeta, shardIndexId } from './shards.js'
 import type { ObjectStorage, ShardCache } from './storage.js'
-import type {
-  BufferedWriteResponse,
-  BufferOp,
-  IndexMeta,
-  IndexSettings,
-  IndexStatusResponse
-} from './types.js'
+import type { BufferedWriteResponse, BufferOp, IndexMeta, IndexSettings, IndexStatusResponse } from './types.js'
 
 export interface CreateIndexInput {
   name: string
-  schema: AnySchema
+  schema?: AnySchema
   settings?: IndexSettings
   shards?: number
 }
@@ -499,10 +493,7 @@ export async function maybeScheduleRebuild(
     return
   }
 
-  if (
-    meta.status === 'building' &&
-    Date.now() - Date.parse(meta.updatedAt) <= REBUILD_STATUS_STALE_MS
-  ) {
+  if (meta.status === 'building' && Date.now() - Date.parse(meta.updatedAt) <= REBUILD_STATUS_STALE_MS) {
     return
   }
 
@@ -663,7 +654,7 @@ export async function runSearch(
   }
 
   const meta = await getIndexMeta(storage, indexId)
-  
+
   if (isShardGroupMeta(meta)) {
     return runShardedSearch(storage, cache, meta, params, options)
   }

--- a/packages/edge-core/src/service.ts
+++ b/packages/edge-core/src/service.ts
@@ -284,7 +284,11 @@ export async function importDocuments(
   }
 
   const version = newVersionId()
-  const db = create({ schema: meta.schema, language: meta.settings.language as any })
+  const db = create({
+    schema: meta.schema,
+    language: meta.settings.language as any,
+    inferSchema: meta.settings.inferSchema
+  })
   const rows = documents.map(({ id, doc }) => ({ id, ...doc }))
   if (rows.length > 0) {
     insertMultiple(db, rows as any)
@@ -394,7 +398,11 @@ async function loadSnapshotDb(storage: ObjectStorage, meta: IndexMeta, cache: Sh
   }
 
   const raw = decode(bytes)
-  const db = create({ schema: meta.schema, language: meta.settings.language as any })
+  const db = create({
+    schema: meta.schema,
+    language: meta.settings.language as any,
+    inferSchema: meta.settings.inferSchema
+  })
   load(db, raw as any)
   setCachedSnapshotDb(key, db, bytes.byteLength)
   return db
@@ -458,7 +466,11 @@ async function loadSearchableDb(
     return null
   }
 
-  const db = create({ schema: meta.schema, language: meta.settings.language as any })
+  const db = create({
+    schema: meta.schema,
+    language: meta.settings.language as any,
+    inferSchema: meta.settings.inferSchema
+  })
   const documents = [...merged.entries()].map(([id, doc]) => ({ id, ...doc }))
   if (documents.length > 0) {
     insertMultiple(db, documents as any)
@@ -585,7 +597,11 @@ async function runRebuild(
       : await freezeBufferForRebuild(storage, indexId)
     const merged = applyBufferOps(baseDocs, bufferOps)
 
-    const db = create({ schema: meta.schema, language: meta.settings.language as any })
+    const db = create({
+      schema: meta.schema,
+      language: meta.settings.language as any,
+      inferSchema: meta.settings.inferSchema
+    })
     const documents = [...merged.entries()].map(([id, doc]) => ({ id, ...doc }))
     if (documents.length > 0) {
       insertMultiple(db, documents as any)
@@ -632,13 +648,6 @@ async function runRebuild(
 
 export interface SearchOptions {
   snapshotCache?: SnapshotDbCacheOptions
-  /**
-   * When set, shard-group searches fan out through this executor (one call
-   * per shard) instead of searching every shard in the current process.
-   * Use it to run each shard search in its own isolate (e.g. a subrequest
-   * per shard) so total index size is not limited by a single isolate's
-   * 128MB memory.
-   */
   executeShardSearch?: (shardId: string, params: SearchInput) => Promise<Record<string, unknown>>
 }
 

--- a/packages/edge-core/src/types.ts
+++ b/packages/edge-core/src/types.ts
@@ -9,6 +9,7 @@ export interface IndexSettings {
   rebuildIntervalSec?: number
   rebuildThresholdOps?: number
   mode?: IndexMode
+  inferSchema?: boolean
 }
 
 export interface IndexMeta {

--- a/packages/edge-core/src/types.ts
+++ b/packages/edge-core/src/types.ts
@@ -14,7 +14,7 @@ export interface IndexSettings {
 export interface IndexMeta {
   id: string
   name: string
-  schema: AnySchema
+  schema?: AnySchema
   settings: IndexSettings
   shards?: { count: number }
   liveVersion: string | null

--- a/packages/edge-core/tests/import.test.ts
+++ b/packages/edge-core/tests/import.test.ts
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
 
 import { createIndex, importDocuments, runSearch } from '../src/service.js'
 import { NoopShardCache } from '../src/storage.js'
@@ -28,12 +28,9 @@ describe('importDocuments', () => {
   it('creates index when --create options are provided', async () => {
     const storage = new MemoryObjectStorage()
 
-    const meta = await importDocuments(
-      storage,
-      'new-catalog',
-      [{ id: 'sku-1', doc: { title: 'Widget' } }],
-      { create: { name: 'New Catalog', schema: { title: 'string' } } }
-    )
+    const meta = await importDocuments(storage, 'new-catalog', [{ id: 'sku-1', doc: { title: 'Widget' } }], {
+      create: { name: 'New Catalog', schema: { title: 'string' } }
+    })
 
     assert.equal(meta.id, 'new-catalog')
     assert.equal(meta.documents, 1)
@@ -51,5 +48,51 @@ describe('importDocuments', () => {
 
     const results = await runSearch(storage, new NoopShardCache(), 'reset', { term: 'fresh' })
     assert.equal((results as { count: number }).count, 1)
+  })
+
+  it('infers the schema from documents when the index has no schema', async () => {
+    const storage = new MemoryObjectStorage()
+    await createIndex(storage, { name: 'schemaless' })
+
+    await importDocuments(storage, 'schemaless', [
+      { id: '1', doc: { title: 'Alpha', price: 10 } },
+      { id: '2', doc: { title: 'Beta', price: 20 } }
+    ])
+
+    const results = await runSearch(storage, new NoopShardCache(), 'schemaless', {
+      term: 'alpha',
+      where: { price: { gte: 5 } }
+    })
+    assert.equal((results as { count: number }).count, 1)
+  })
+
+  it('indexes undeclared fields when inferSchema is enabled on a partial schema', async () => {
+    const storage = new MemoryObjectStorage()
+    await createIndex(storage, {
+      name: 'hybrid',
+      schema: { embedding: 'vector[3]' },
+      settings: { inferSchema: true }
+    })
+
+    await importDocuments(storage, 'hybrid', [
+      { id: '1', doc: { title: 'Gamma', embedding: [1, 0, 0] } },
+      { id: '2', doc: { title: 'Delta', embedding: [0, 1, 0] } }
+    ])
+
+    const results = await runSearch(storage, new NoopShardCache(), 'hybrid', { term: 'gamma' })
+    assert.equal((results as { count: number }).count, 1)
+  })
+
+  it('ignores undeclared fields on a partial schema without inferSchema', async () => {
+    const storage = new MemoryObjectStorage()
+    await createIndex(storage, {
+      name: 'strict-partial',
+      schema: { embedding: 'vector[3]' }
+    })
+
+    await importDocuments(storage, 'strict-partial', [{ id: '1', doc: { title: 'Epsilon', embedding: [1, 0, 0] } }])
+
+    const results = await runSearch(storage, new NoopShardCache(), 'strict-partial', { term: 'epsilon' })
+    assert.equal((results as { count: number }).count, 0)
   })
 })

--- a/packages/edge-index-builder/src/cli.ts
+++ b/packages/edge-index-builder/src/cli.ts
@@ -16,6 +16,7 @@ function parseArgs(argv: string[]): {
   schemaFile?: string
   language?: string
   shards?: number
+  inferSchema?: boolean
 } {
   const [command, indexId, filePath, ...rest] = argv
   let create = false
@@ -24,11 +25,16 @@ function parseArgs(argv: string[]): {
   let schemaFile: string | undefined
   let language: string | undefined
   let shards: number | undefined
+  let inferSchema: boolean | undefined
 
   for (let i = 0; i < rest.length; i++) {
     const arg = rest[i]!
     if (arg === '--create') {
       create = true
+      continue
+    }
+    if (arg === '--infer-schema') {
+      inferSchema = true
       continue
     }
     if (arg === '--name') {
@@ -67,7 +73,7 @@ function parseArgs(argv: string[]): {
     }
   }
 
-  return { command: command ?? '', indexId, filePath, create, name, schema, schemaFile, language, shards }
+  return { command: command ?? '', indexId, filePath, create, name, schema, schemaFile, language, shards, inferSchema }
 }
 
 async function runImport(
@@ -80,6 +86,7 @@ async function runImport(
     schemaFile?: string
     language?: string
     shards?: number
+    inferSchema?: boolean
   }
 ): Promise<void> {
   const storage = createS3StorageFromEnv()
@@ -90,6 +97,14 @@ async function runImport(
     schema = JSON.parse(await readFile(options.schemaFile, 'utf8')) as CreateIndexInput['schema']
   }
 
+  const settings =
+    options.language || options.inferSchema
+      ? {
+          ...(options.language ? { language: options.language } : {}),
+          ...(options.inferSchema ? { inferSchema: true } : {})
+        }
+      : undefined
+
   if (options.shards !== undefined) {
     const result = await importShardedDocuments(storage, indexId, documents, {
       shards: options.shards,
@@ -97,7 +112,7 @@ async function runImport(
         ? {
             name: options.name ?? indexId,
             ...(schema ? { schema } : {}),
-            settings: options.language ? { language: options.language } : undefined
+            settings
           }
         : undefined
     })
@@ -111,7 +126,7 @@ async function runImport(
       ? {
           name: options.name ?? indexId,
           ...(schema ? { schema } : {}),
-          settings: options.language ? { language: options.language } : undefined
+          settings
         }
       : undefined
   })
@@ -161,7 +176,8 @@ async function main(): Promise<void> {
       schema: args.schema,
       schemaFile: args.schemaFile,
       language: args.language,
-      shards: args.shards
+      shards: args.shards,
+      inferSchema: args.inferSchema
     })
     return
   }
@@ -169,7 +185,7 @@ async function main(): Promise<void> {
   console.log(`Usage:
   zbsearch-edge-builder rebuild [indexId]
   zbsearch-edge-builder rebuild --all
-  zbsearch-edge-builder import <indexId> <file> [--create] [--name <name>] [--schema '<json>'] [--schema-file <path>] [--language <lang>] [--shards <n>]`)
+  zbsearch-edge-builder import <indexId> <file> [--create] [--name <name>] [--schema '<json>'] [--schema-file <path>] [--language <lang>] [--shards <n>] [--infer-schema]`)
   process.exit(1)
 }
 

--- a/packages/edge-index-builder/src/cli.ts
+++ b/packages/edge-index-builder/src/cli.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 import { readFile } from 'node:fs/promises'
-
-import { importDocuments, importShardedDocuments, rebuildIndex, listIndexMetas } from '@zbsearch/edge-core'
 import type { CreateIndexInput } from '@zbsearch/edge-core'
+import { importDocuments, importShardedDocuments, listIndexMetas, rebuildIndex } from '@zbsearch/edge-core'
 import { createS3StorageFromEnv } from '@zbsearch/storage-s3'
 
 import { loadImportDocuments } from './import-documents.js'
@@ -94,14 +93,13 @@ async function runImport(
   if (options.shards !== undefined) {
     const result = await importShardedDocuments(storage, indexId, documents, {
       shards: options.shards,
-      create:
-        options.create && schema
-          ? {
-              name: options.name ?? indexId,
-              schema,
-              settings: options.language ? { language: options.language } : undefined
-            }
-          : undefined
+      create: options.create
+        ? {
+            name: options.name ?? indexId,
+            ...(schema ? { schema } : {}),
+            settings: options.language ? { language: options.language } : undefined
+          }
+        : undefined
     })
 
     console.log(JSON.stringify(result))
@@ -109,14 +107,13 @@ async function runImport(
   }
 
   const meta = await importDocuments(storage, indexId, documents, {
-    create:
-      options.create && schema
-        ? {
-            name: options.name ?? indexId,
-            schema,
-            settings: options.language ? { language: options.language } : undefined
-          }
-        : undefined
+    create: options.create
+      ? {
+          name: options.name ?? indexId,
+          ...(schema ? { schema } : {}),
+          settings: options.language ? { language: options.language } : undefined
+        }
+      : undefined
   })
 
   console.log(

--- a/packages/zbsearch/README.md
+++ b/packages/zbsearch/README.md
@@ -227,7 +227,7 @@ Read the complete documentation at [https://zbsearch.dev](https://zbsearch.dev).
 - [Plugin QPS](https://zbsearch.dev/docs/zbsearch/plugins/plugin-qps)
 - [Plugin PT15](https://zbsearch.dev/docs/zbsearch/plugins/plugin-pt15)
 
-Write your own plugin: [https://zbsearch.dev](https://zbsearch.dev)
+Write your own plugin: [https://www.zbsearch.dev/docs/zbsearch/plugins/writing-your-own-plugins](https://www.zbsearch.dev/docs/zbsearch/plugins/writing-your-own-plugins)
 
 # License
 

--- a/packages/zbsearch/README.md
+++ b/packages/zbsearch/README.md
@@ -130,6 +130,28 @@ ZBSearch currently supports 10 different data types:
 | `enum[]`         | An array of enums.                                                          | `['comedy', 'action', 'romance']`                                           |
 | `vector[<size>]` | A vector of numbers to perform vector search on.                            | `[0.403, 0.192, 0.830]`                                                     |
 
+## Schema inference (optional schema)
+
+The schema is optional. If you omit it, ZBSearch infers the type of every document property on first sight and indexes it on the fly:
+
+```js
+const db = create()
+
+insert(db, { name: 'Noise cancelling headphones', price: 99.99, meta: { rating: 4.5 } })
+// db.schema is now: { name: 'string', price: 'number', meta: { rating: 'number' } }
+```
+
+Types lock on first sight (a later conflicting value is rejected with `SCHEMA_VALIDATION_FAILURE`), and objects shaped like `{ lat, lon }` are inferred as `geopoint`. Vectors are the only types that are never inferred - a `number[]` is indistinguishable from an embedding — so embedding properties must still be declared, and they can be the only thing you declare:
+
+```js
+const db = create({
+  schema: { embedding: 'vector[1536]' },
+  inferSchema: true, // a provided schema is strict by default; this opts undeclared fields into inference
+})
+```
+
+Passing a schema keeps the classic strict behavior (undeclared fields are stored but not indexed). See the [official docs](https://zbsearch.dev) for the full inference rules.
+
 # Vector and Hybrid Search Support
 
 ZBSearch supports both vector and hybrid search by just setting `mode: 'vector'` when performing search.

--- a/packages/zbsearch/src/components/index.ts
+++ b/packages/zbsearch/src/components/index.ts
@@ -1,3 +1,13 @@
+import { createError } from '../errors.js'
+import type { InsertOptions } from '../methods/insert.js'
+import { AVLTree } from '../trees/avl.js'
+import type { Point as BKDGeoPoint, Point } from '../trees/bkd.js'
+import { BKDTree } from '../trees/bkd.js'
+import { BoolNode } from '../trees/bool.js'
+import { FlatTree } from '../trees/flat.js'
+import { FindResult, RadixNodeJSON, RadixTree } from '../trees/radix.js'
+import { VectorType } from '../trees/vector.js'
+import { deserializeVectorIndex, resolveVectorIndexFactory } from '../trees/vector-index.js'
 import type {
   AnyIndexStore,
   AnyZBSearch,
@@ -17,17 +27,7 @@ import type {
   TokenScore,
   WhereCondition
 } from '../types.js'
-import type { InsertOptions } from '../methods/insert.js'
-import type { Point as BKDGeoPoint } from '../trees/bkd.js'
-import type { Point } from '../trees/bkd.js'
-import { FindResult, RadixNodeJSON, RadixTree } from '../trees/radix.js'
-import { createError } from '../errors.js'
-import { AVLTree } from '../trees/avl.js'
-import { FlatTree } from '../trees/flat.js'
-import { BKDTree } from '../trees/bkd.js'
-import { BoolNode } from '../trees/bool.js'
-
-import { convertDistanceToMeters, setIntersection, setUnion, setDifference } from '../utils.js'
+import { convertDistanceToMeters, setDifference, setIntersection, setUnion } from '../utils.js'
 import { BM25 } from './algorithms.js'
 import { getInnerType, getVectorSize, isArrayType, isVectorType } from './defaults.js'
 import {
@@ -36,8 +36,6 @@ import {
   InternalDocumentID,
   InternalDocumentIDStore
 } from './internal-document-id-store.js'
-import { VectorType } from '../trees/vector.js'
-import { deserializeVectorIndex, resolveVectorIndexFactory } from '../trees/vector-index.js'
 
 export type FrequencyMap = {
   [property: string]: {
@@ -86,8 +84,7 @@ export function insertDocumentScoreParameters(
 ): InternalDocumentID {
   const resolvedInternalId = internalId ?? getInternalDocumentId(index.sharedInternalDocumentStore, id)
 
-  index.avgFieldLength[prop] =
-    ((index.avgFieldLength[prop] ?? 0) * (docsCount - 1) + tokens.length) / docsCount
+  index.avgFieldLength[prop] = ((index.avgFieldLength[prop] ?? 0) * (docsCount - 1) + tokens.length) / docsCount
   index.fieldLengths[prop][resolvedInternalId] = tokens.length
   index.frequencies[prop][resolvedInternalId] = {}
 
@@ -189,51 +186,61 @@ export function create<T extends AnyZBSearch, TSchema extends T['schema']>(
       continue
     }
 
-    if (isVectorType(type)) {
-      const factory = resolveVectorIndexFactory(path, zbsearch.indexes)
-      index.searchableProperties.push(path)
-      index.searchablePropertiesWithTypes[path] = type
-      index.vectorIndexes[path] = {
-        type: 'Vector',
-        node: factory({ dim: getVectorSize(type), property: path }),
-        isArray: false
-      }
-    } else {
-      const isArray = /\[/.test(type as string)
-      switch (type) {
-        case 'boolean':
-        case 'boolean[]':
-          index.indexes[path] = { type: 'Bool', node: new BoolNode(), isArray }
-          break
-        case 'number':
-        case 'number[]':
-          index.indexes[path] = { type: 'AVL', node: new AVLTree<number, InternalDocumentID>(0, []), isArray }
-          break
-        case 'string':
-        case 'string[]':
-          index.indexes[path] = { type: 'Radix', node: new RadixTree(), isArray }
-          index.avgFieldLength[path] = 0
-          index.frequencies[path] = {}
-          index.tokenOccurrences[path] = {}
-          index.fieldLengths[path] = {}
-          break
-        case 'enum':
-        case 'enum[]':
-          index.indexes[path] = { type: 'Flat', node: new FlatTree(), isArray }
-          break
-        case 'geopoint':
-          index.indexes[path] = { type: 'BKD', node: new BKDTree(), isArray }
-          break
-        default:
-          throw createError('INVALID_SCHEMA_TYPE', Array.isArray(type) ? 'array' : type, path)
-      }
-
-      index.searchableProperties.push(path)
-      index.searchablePropertiesWithTypes[path] = type
-    }
+    addSearchablePropertyToIndex(zbsearch, index, path, type)
   }
 
   return index
+}
+
+export function addSearchablePropertyToIndex<T extends AnyZBSearch>(
+  zbsearch: T,
+  index: Index,
+  path: string,
+  type: SearchableType
+): void {
+  if (isVectorType(type)) {
+    const factory = resolveVectorIndexFactory(path, zbsearch.indexes)
+    index.searchableProperties.push(path)
+    index.searchablePropertiesWithTypes[path] = type
+    index.vectorIndexes[path] = {
+      type: 'Vector',
+      node: factory({ dim: getVectorSize(type), property: path }),
+      isArray: false
+    }
+    return
+  }
+
+  const isArray = /\[/.test(type as string)
+  switch (type) {
+    case 'boolean':
+    case 'boolean[]':
+      index.indexes[path] = { type: 'Bool', node: new BoolNode(), isArray }
+      break
+    case 'number':
+    case 'number[]':
+      index.indexes[path] = { type: 'AVL', node: new AVLTree<number, InternalDocumentID>(0, []), isArray }
+      break
+    case 'string':
+    case 'string[]':
+      index.indexes[path] = { type: 'Radix', node: new RadixTree(), isArray }
+      index.avgFieldLength[path] = 0
+      index.frequencies[path] = {}
+      index.tokenOccurrences[path] = {}
+      index.fieldLengths[path] = {}
+      break
+    case 'enum':
+    case 'enum[]':
+      index.indexes[path] = { type: 'Flat', node: new FlatTree(), isArray }
+      break
+    case 'geopoint':
+      index.indexes[path] = { type: 'BKD', node: new BKDTree(), isArray }
+      break
+    default:
+      throw createError('INVALID_SCHEMA_TYPE', Array.isArray(type) ? 'array' : type, path)
+  }
+
+  index.searchableProperties.push(path)
+  index.searchablePropertiesWithTypes[path] = type
 }
 
 function insertScalarValue(
@@ -493,10 +500,7 @@ function collectFindResultIds(searchResult: FindResult): Set<InternalDocumentID>
   return ids
 }
 
-function filterIdsToCandidates(
-  ids: InternalDocumentID[],
-  candidates: Set<InternalDocumentID>
-): InternalDocumentID[] {
+function filterIdsToCandidates(ids: InternalDocumentID[], candidates: Set<InternalDocumentID>): InternalDocumentID[] {
   const filtered: InternalDocumentID[] = []
 
   for (let i = 0; i < ids.length; i++) {

--- a/packages/zbsearch/src/components/inference.ts
+++ b/packages/zbsearch/src/components/inference.ts
@@ -27,8 +27,7 @@ function inferTypeFromValue(value: unknown): SearchableType | undefined {
     return undefined
   }
 
-  // getDocumentProperties already treats any object with numeric lat/lon as
-  // a geopoint value, so inferring `geopoint` is the only consistent choice.
+  // getDocumentProperties already treats any object with numeric lat/lon as a geopoint value, so inferring `geopoint` is the only consistent choice.
   if (typeof value === 'object' && value !== null) {
     const point = value as { lat?: unknown; lon?: unknown }
     if (typeof point.lat === 'number' && typeof point.lon === 'number') {
@@ -65,6 +64,16 @@ function flattenDocument(doc: AnyDocument, prefix: string, leaves: Array<[string
   }
 }
 
+function hasPathConflict(knownProperties: Record<string, SearchableType>, path: string): boolean {
+  for (const known of Object.keys(knownProperties)) {
+    if (path.startsWith(`${known}.`) || known.startsWith(`${path}.`)) {
+      return true
+    }
+  }
+
+  return false
+}
+
 function setNestedSchemaProperty(schema: AnySchema, path: string, type: SearchableType): void {
   const tokens = path.split('.')
   const lastToken = tokens[tokens.length - 1]!
@@ -82,17 +91,6 @@ function setNestedSchemaProperty(schema: AnySchema, path: string, type: Searchab
   current[lastToken] = type
 }
 
-/**
- * Infers schema types for document properties that are not yet known to the
- * index, registering the corresponding index and sorter structures on the fly.
- *
- * Vectors and enums are never inferred: vectors must be declared in the
- * schema (e.g. `vector[512]`), and enums are only reachable through an
- * explicit schema. Objects with numeric `lat`/`lon` are inferred as
- * `geopoint`, mirroring how getDocumentProperties treats them.
- *
- * Returns `true` when at least one new property was registered.
- */
 export function inferSchemaFromDocument<T extends AnyZBSearch>(zbsearch: T, doc: AnyDocument): boolean {
   if (!zbsearch.inferSchema) {
     return false
@@ -110,9 +108,7 @@ export function inferSchemaFromDocument<T extends AnyZBSearch>(zbsearch: T, doc:
   for (const [path, value] of leaves) {
     const knownType = knownProperties[path]
     if (knownType) {
-      // The index already knows this property (e.g. after load()): make sure
-      // the runtime schema reflects its type so validateSchema keeps
-      // enforcing it.
+      // The index already knows this property (e.g. after load()): make sure the runtime schema reflects its type so validateSchema keeps enforcing it.
       if (getNested(zbsearch.schema as object, path) !== knownType) {
         setNestedSchemaProperty(zbsearch.schema as AnySchema, path, knownType)
       }
@@ -121,6 +117,12 @@ export function inferSchemaFromDocument<T extends AnyZBSearch>(zbsearch: T, doc:
 
     const type = inferTypeFromValue(value)
     if (!type) {
+      continue
+    }
+
+    if (hasPathConflict(knownProperties, path)) {
+      // A known property is a prefix of this path (e.g. `a` scalar, new `a.b`) or the reverse: the document shape conflicts with the locked type of
+      // the existing property. Skip registration and let validateSchema reject the document instead of corrupting the schema.
       continue
     }
 

--- a/packages/zbsearch/src/components/inference.ts
+++ b/packages/zbsearch/src/components/inference.ts
@@ -1,0 +1,140 @@
+import { RESERVED_VECTOR_INDEX_KEY } from '../constants.js'
+import type { AnyDocument, AnySchema, AnyZBSearch, SearchableType } from '../types.js'
+import { getNested } from '../utils.js'
+import { addSearchablePropertyToIndex, type Index } from './index.js'
+import { addSortablePropertyToSorter, type Sorter } from './sorter.js'
+
+function inferTypeFromValue(value: unknown): SearchableType | undefined {
+  switch (typeof value) {
+    case 'string':
+      return 'string'
+    case 'number':
+      return 'number'
+    case 'boolean':
+      return 'boolean'
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return undefined
+    }
+
+    const innerType = inferTypeFromValue(value[0])
+    if (innerType === 'string' || innerType === 'number' || innerType === 'boolean') {
+      return `${innerType}[]` as SearchableType
+    }
+
+    return undefined
+  }
+
+  // getDocumentProperties already treats any object with numeric lat/lon as
+  // a geopoint value, so inferring `geopoint` is the only consistent choice.
+  if (typeof value === 'object' && value !== null) {
+    const point = value as { lat?: unknown; lon?: unknown }
+    if (typeof point.lat === 'number' && typeof point.lon === 'number') {
+      return 'geopoint'
+    }
+  }
+
+  return undefined
+}
+
+function flattenDocument(doc: AnyDocument, prefix: string, leaves: Array<[string, unknown]>): void {
+  for (const [key, value] of Object.entries(doc)) {
+    if (key === 'id' || key === RESERVED_VECTOR_INDEX_KEY) {
+      continue
+    }
+
+    if (value === null || typeof value === 'undefined') {
+      continue
+    }
+
+    const path = prefix ? `${prefix}.${key}` : key
+
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      if (typeof (value as AnyDocument).lat === 'number' && typeof (value as AnyDocument).lon === 'number') {
+        leaves.push([path, value])
+        continue
+      }
+
+      flattenDocument(value as AnyDocument, path, leaves)
+      continue
+    }
+
+    leaves.push([path, value])
+  }
+}
+
+function setNestedSchemaProperty(schema: AnySchema, path: string, type: SearchableType): void {
+  const tokens = path.split('.')
+  const lastToken = tokens[tokens.length - 1]!
+
+  let current = schema
+  for (let i = 0; i < tokens.length - 1; i++) {
+    const token = tokens[i]!
+    const next = current[token]
+    if (typeof next !== 'object' || next === null || Array.isArray(next)) {
+      current[token] = {}
+    }
+    current = current[token] as AnySchema
+  }
+
+  current[lastToken] = type
+}
+
+/**
+ * Infers schema types for document properties that are not yet known to the
+ * index, registering the corresponding index and sorter structures on the fly.
+ *
+ * Vectors and enums are never inferred: vectors must be declared in the
+ * schema (e.g. `vector[512]`), and enums are only reachable through an
+ * explicit schema. Objects with numeric `lat`/`lon` are inferred as
+ * `geopoint`, mirroring how getDocumentProperties treats them.
+ *
+ * Returns `true` when at least one new property was registered.
+ */
+export function inferSchemaFromDocument<T extends AnyZBSearch>(zbsearch: T, doc: AnyDocument): boolean {
+  if (!zbsearch.inferSchema) {
+    return false
+  }
+
+  const leaves: Array<[string, unknown]> = []
+  flattenDocument(doc, '', leaves)
+
+  const index = zbsearch.data.index as Index
+  const sorter = zbsearch.data.sorting as Sorter
+  const knownProperties = zbsearch.index.getSearchablePropertiesWithTypes(index)
+
+  let changed = false
+
+  for (const [path, value] of leaves) {
+    const knownType = knownProperties[path]
+    if (knownType) {
+      // The index already knows this property (e.g. after load()): make sure
+      // the runtime schema reflects its type so validateSchema keeps
+      // enforcing it.
+      if (getNested(zbsearch.schema as object, path) !== knownType) {
+        setNestedSchemaProperty(zbsearch.schema as AnySchema, path, knownType)
+      }
+      continue
+    }
+
+    const type = inferTypeFromValue(value)
+    if (!type) {
+      continue
+    }
+
+    addSearchablePropertyToIndex(zbsearch, index, path, type)
+    addSortablePropertyToSorter(sorter, path, type)
+    setNestedSchemaProperty(zbsearch.schema as AnySchema, path, type)
+
+    knownProperties[path] = type
+    changed = true
+  }
+
+  if (changed) {
+    zbsearch.caches = {}
+  }
+
+  return changed
+}

--- a/packages/zbsearch/src/components/sorter.ts
+++ b/packages/zbsearch/src/components/sorter.ts
@@ -1,7 +1,7 @@
 import { createError } from '../errors.js'
 import {
-  AnyZBSearch,
   AnySorterStore,
+  AnyZBSearch,
   ISorter,
   SearchableType,
   SorterConfig,
@@ -9,6 +9,7 @@ import {
   SortType,
   SortValue
 } from '../types.js'
+import { safeArrayPush } from '../utils.js'
 import { isVectorType } from './defaults.js'
 import {
   DocumentID,
@@ -16,7 +17,6 @@ import {
   InternalDocumentID,
   InternalDocumentIDStore
 } from './internal-document-id-store.js'
-import { safeArrayPush } from '../utils.js'
 import { getLocale } from './tokenizer/languages.js'
 
 interface PropertySort<K> {
@@ -38,6 +38,31 @@ export interface Sorter extends AnySorterStore {
   sortableProperties: string[]
   sortablePropertiesWithTypes: Record<string, SortType>
   sorts: Record<string, PropertySort<number | string | boolean>>
+  unsortableProperties: string[]
+}
+
+export function addSortablePropertyToSorter(sorter: Sorter, path: string, type: SearchableType): void {
+  if (!sorter.enabled || (sorter.unsortableProperties ?? []).includes(path)) {
+    return
+  }
+
+  switch (type) {
+    case 'boolean':
+    case 'number':
+    case 'string':
+      sorter.sortableProperties.push(path)
+      sorter.sortablePropertiesWithTypes[path] = type
+      sorter.sorts[path] = {
+        docs: new Map(),
+        orderedDocsToRemove: new Map(),
+        orderedDocs: [],
+        type: type
+      }
+      break
+    default:
+      // We don't allow to sort by arrays, enums, geopoints, or vectors
+      return
+  }
 }
 
 function innerCreate<T extends AnyZBSearch>(
@@ -54,7 +79,8 @@ function innerCreate<T extends AnyZBSearch>(
     isSorted: true,
     sortableProperties: [],
     sortablePropertiesWithTypes: {},
-    sorts: {}
+    sorts: {},
+    unsortableProperties: sortableDeniedProperties
   }
 
   for (const [prop, type] of Object.entries<SearchableType>(schema)) {
@@ -79,33 +105,28 @@ function innerCreate<T extends AnyZBSearch>(
       continue
     }
 
-    if (!isVectorType(type)) {
-      switch (type) {
-        case 'boolean':
-        case 'number':
-        case 'string':
-          sorter.sortableProperties.push(path)
-          sorter.sortablePropertiesWithTypes[path] = type
-          sorter.sorts[path] = {
-            docs: new Map(),
-            orderedDocsToRemove: new Map(),
-            orderedDocs: [],
-            type: type
-          }
-          break
-        case 'geopoint':
-        case 'enum':
-          // We don't allow to sort by enums or geopoints
-          continue
-        case 'enum[]':
-        case 'boolean[]':
-        case 'number[]':
-        case 'string[]':
-          // We don't allow to sort by arrays
-          continue
-        default:
-          throw createError('INVALID_SORT_SCHEMA_TYPE', Array.isArray(type) ? 'array' : type, path)
-      }
+    if (isVectorType(type)) {
+      continue
+    }
+
+    switch (type) {
+      case 'boolean':
+      case 'number':
+      case 'string':
+        addSortablePropertyToSorter(sorter, path, type)
+        break
+      case 'geopoint':
+      case 'enum':
+        // We don't allow to sort by enums or geopoints
+        continue
+      case 'enum[]':
+      case 'boolean[]':
+      case 'number[]':
+      case 'string[]':
+        // We don't allow to sort by arrays
+        continue
+      default:
+        throw createError('INVALID_SORT_SCHEMA_TYPE', Array.isArray(type) ? 'array' : type, path)
     }
   }
 
@@ -331,7 +352,8 @@ export function load<R = unknown>(sharedInternalDocumentStore: InternalDocumentI
     sortablePropertiesWithTypes: rawDocument.sortablePropertiesWithTypes,
     sorts,
     enabled: true,
-    isSorted: rawDocument.isSorted
+    isSorted: rawDocument.isSorted,
+    unsortableProperties: rawDocument.unsortableProperties ?? []
   }
 }
 

--- a/packages/zbsearch/src/components/sorter.ts
+++ b/packages/zbsearch/src/components/sorter.ts
@@ -388,7 +388,8 @@ export function save<R = unknown>(sorter: Sorter): R {
     sortablePropertiesWithTypes: sorter.sortablePropertiesWithTypes,
     sorts,
     enabled: sorter.enabled,
-    isSorted: sorter.isSorted
+    isSorted: sorter.isSorted,
+    unsortableProperties: sorter.unsortableProperties ?? []
   } as R
 }
 

--- a/packages/zbsearch/src/methods/create.ts
+++ b/packages/zbsearch/src/methods/create.ts
@@ -1,12 +1,18 @@
-import { formatElapsedTime, getDocumentIndexId, getDocumentProperties, validateSchema, assertSchemaHasNoReservedKeys } from '../components/defaults.js'
-import { DocumentsStore, createDocumentsStore } from '../components/documents-store.js'
-import { AVAILABLE_PLUGIN_HOOKS, getAllPluginsByHook } from '../components/plugins.js'
+import {
+  assertSchemaHasNoReservedKeys,
+  formatElapsedTime,
+  getDocumentIndexId,
+  getDocumentProperties,
+  validateSchema
+} from '../components/defaults.js'
+import { createDocumentsStore, DocumentsStore } from '../components/documents-store.js'
 import { FUNCTION_COMPONENTS, OBJECT_COMPONENTS, runAfterCreate } from '../components/hooks.js'
-import { Index, createIndex } from '../components/index.js'
+import { createIndex, Index } from '../components/index.js'
 import { createInternalDocumentIDStore } from '../components/internal-document-id-store.js'
-import { Sorter, createSorter } from '../components/sorter.js'
-import { createTokenizer } from '../components/tokenizer/index.js'
 import { createPinning } from '../components/pinning.js'
+import { AVAILABLE_PLUGIN_HOOKS, getAllPluginsByHook } from '../components/plugins.js'
+import { createSorter, Sorter } from '../components/sorter.js'
+import { createTokenizer } from '../components/tokenizer/index.js'
 import { createError } from '../errors.js'
 import {
   AnySchema,
@@ -17,15 +23,16 @@ import {
   IndexesConfig,
   ISorter,
   ObjectComponents,
-  ZBSearch,
-  ZBSearchPlugin,
   SorterConfig,
-  Tokenizer
+  Tokenizer,
+  ZBSearch,
+  ZBSearchPlugin
 } from '../types.js'
 import { uniqueId } from '../utils.js'
 
 interface CreateArguments<ZBSearchSchema, TIndex, TDocumentStore, TSorter, TPinning> {
-  schema: ZBSearchSchema
+  schema?: ZBSearchSchema
+  inferSchema?: boolean
   indexes?: IndexesConfig
   sort?: SorterConfig
   language?: string
@@ -76,26 +83,25 @@ function validateComponents<
 }
 
 export function create<
-  ZBSearchSchema extends AnySchema,
+  // `any` (not AnySchema) is the deliberate default for schemaless usage:
+  // it routes to the loose, already-supported typing path and avoids
+  // distributing the schema-mapped types over an index signature.
+  ZBSearchSchema extends AnySchema = any,
   TIndex = IIndex<Index>,
   TDocumentStore = IDocumentsStore<DocumentsStore>,
   TSorter = ISorter<Sorter>,
   TPinning = any
->({
-  schema,
-  indexes,
-  sort,
-  language,
-  components,
-  id,
-  plugins
-}: CreateArguments<ZBSearchSchema, TIndex, TDocumentStore, TSorter, TPinning>): ZBSearch<
-  ZBSearchSchema,
-  TIndex,
-  TDocumentStore,
-  TSorter,
-  TPinning
-> {
+>(
+  args: CreateArguments<ZBSearchSchema, TIndex, TDocumentStore, TSorter, TPinning> = {}
+): ZBSearch<ZBSearchSchema, TIndex, TDocumentStore, TSorter, TPinning> {
+  const { indexes, sort, language, plugins } = args
+  let { id } = args
+  const schema = (args.schema ?? {}) as ZBSearchSchema
+  // When no schema is provided, schema inference defaults to on.
+  // When a schema is provided, it is enforced strictly unless inference is explicitly enabled for undeclared properties.
+  const inferSchema = args.inferSchema ?? args.schema === undefined
+  let components = args.components
+
   if (!components) {
     components = {}
   }
@@ -169,6 +175,7 @@ export function create<
     data: {},
     caches: {},
     schema,
+    inferSchema,
     tokenizer,
     index,
     sorter,

--- a/packages/zbsearch/src/methods/insert.ts
+++ b/packages/zbsearch/src/methods/insert.ts
@@ -1,10 +1,19 @@
-import type { AnyZBSearch, PartialSchemaDeep, SearchableType, SortType, SortValue, TypedDocument } from '../types.js'
-import { isArrayType, isGeoPointType, isVectorType } from '../components.js'
-import { isAsyncFunction, sleep } from '../utils.js'
 import { runMultipleHook, runSingleHook } from '../components/hooks.js'
+import { inferSchemaFromDocument } from '../components/inference.js'
+import { getInternalDocumentId } from '../components/internal-document-id-store.js'
+import { isArrayType, isGeoPointType, isVectorType } from '../components.js'
 import { createError } from '../errors.js'
 import { Point } from '../trees/bkd.js'
-import { getInternalDocumentId } from '../components/internal-document-id-store.js'
+import type {
+  AnyDocument,
+  AnyZBSearch,
+  PartialSchemaDeep,
+  SearchableType,
+  SortType,
+  SortValue,
+  TypedDocument
+} from '../types.js'
+import { isAsyncFunction, sleep } from '../utils.js'
 
 export type InsertOptions = {
   avlRebalanceThreshold?: number
@@ -17,6 +26,8 @@ export function insert<T extends AnyZBSearch>(
   skipHooks?: boolean,
   options?: InsertOptions
 ): string | Promise<string> {
+  inferSchemaFromDocument(zbsearch, doc as AnyDocument)
+
   const errorProperty = zbsearch.validateSchema(doc, zbsearch.schema)
   if (errorProperty) {
     throw createError('SCHEMA_VALIDATION_FAILURE', errorProperty)
@@ -143,12 +154,8 @@ function innerInsertSync<T extends AnyZBSearch>(
 
   const docsCount = zbsearch.documentsStore.count(docs)
 
-  const {
-    indexableProperties,
-    indexablePropertiesWithTypes,
-    sortableProperties,
-    sortablePropertiesWithTypes
-  } = getInsertMetadata(zbsearch)
+  const { indexableProperties, indexablePropertiesWithTypes, sortableProperties, sortablePropertiesWithTypes } =
+    getInsertMetadata(zbsearch)
   const indexableValues = zbsearch.getDocumentProperties(doc, indexableProperties)
 
   for (const [key, value] of Object.entries(indexableValues)) {
@@ -278,8 +285,7 @@ function indexAndSortDocumentSync<T extends AnyZBSearch>(
   cachedSortableProperties?: string[],
   cachedSortableTypes?: Record<string, SortType>
 ) {
-  const indexTypes =
-    cachedIndexTypes ?? zbsearch.index.getSearchablePropertiesWithTypes(zbsearch.data.index)
+  const indexTypes = cachedIndexTypes ?? zbsearch.index.getSearchablePropertiesWithTypes(zbsearch.data.index)
   const internalDocumentId = getInternalDocumentId(zbsearch.internalDocumentIDStore, id)
 
   for (const prop of indexableProperties) {
@@ -323,10 +329,8 @@ function indexAndSortDocumentSync<T extends AnyZBSearch>(
     )
   }
 
-  const sortableProperties =
-    cachedSortableProperties ?? zbsearch.sorter.getSortableProperties(zbsearch.data.sorting)
-  const sortableTypes =
-    cachedSortableTypes ?? zbsearch.sorter.getSortablePropertiesWithTypes(zbsearch.data.sorting)
+  const sortableProperties = cachedSortableProperties ?? zbsearch.sorter.getSortableProperties(zbsearch.data.sorting)
+  const sortableTypes = cachedSortableTypes ?? zbsearch.sorter.getSortablePropertiesWithTypes(zbsearch.data.sorting)
   const sortableValues = zbsearch.getDocumentProperties(doc, sortableProperties)
 
   for (const prop of sortableProperties) {
@@ -425,16 +429,18 @@ function innerInsertMultipleSync<T extends AnyZBSearch>(
     const batch = docs.slice(i * batchSize, (i + 1) * batchSize)
     if (batch.length === 0) return false
 
-    const {
-      indexableProperties,
-      indexablePropertiesWithTypes,
-      sortableProperties,
-      sortablePropertiesWithTypes
-    } = getInsertMetadata(zbsearch)
+    let { indexableProperties, indexablePropertiesWithTypes, sortableProperties, sortablePropertiesWithTypes } =
+      getInsertMetadata(zbsearch)
     const batchOptions = { avlRebalanceThreshold: batch.length }
     const { docs: docsStore } = zbsearch.data
 
     for (const doc of batch) {
+      if (inferSchemaFromDocument(zbsearch, doc as AnyDocument)) {
+        // New properties were registered: refresh the memoized metadata.
+        ;({ indexableProperties, indexablePropertiesWithTypes, sortableProperties, sortablePropertiesWithTypes } =
+          getInsertMetadata(zbsearch))
+      }
+
       const errorProperty = zbsearch.validateSchema(doc, zbsearch.schema)
       if (errorProperty) {
         throw createError('SCHEMA_VALIDATION_FAILURE', errorProperty)

--- a/packages/zbsearch/src/types.ts
+++ b/packages/zbsearch/src/types.ts
@@ -1,16 +1,15 @@
-import type { InsertOptions } from './methods/insert.js'
-import { MODE_FULLTEXT_SEARCH, MODE_HYBRID_SEARCH, MODE_VECTOR_SEARCH, RESERVED_VECTOR_INDEX_KEY } from './constants.js'
 import { DocumentsStore } from './components/documents-store.js'
 import { Index, TTree } from './components/index.js'
 import { DocumentID, InternalDocumentID, InternalDocumentIDStore } from './components/internal-document-id-store.js'
 import { Sorter } from './components/sorter.js'
 import { Language } from './components/tokenizer/languages.js'
+import { MODE_FULLTEXT_SEARCH, MODE_HYBRID_SEARCH, MODE_VECTOR_SEARCH, RESERVED_VECTOR_INDEX_KEY } from './constants.js'
+import type { InsertOptions } from './methods/insert.js'
 import { Point } from './trees/bkd.js'
 import { VectorIndex, VectorType, VectorTypeLike } from './trees/vector.js'
 
-export { MODE_FULLTEXT_SEARCH, MODE_HYBRID_SEARCH, MODE_VECTOR_SEARCH, RESERVED_VECTOR_INDEX_KEY } from './constants.js'
-
 export type { DefaultTokenizer } from './components/tokenizer/index.js'
+export { MODE_FULLTEXT_SEARCH, MODE_HYBRID_SEARCH, MODE_VECTOR_SEARCH, RESERVED_VECTOR_INDEX_KEY } from './constants.js'
 
 export type Nullable<T> = T | null
 
@@ -1328,6 +1327,7 @@ type Internals<
   }
   internalDocumentIDStore: InternalDocumentIDStore
   caches: Record<string, unknown>
+  inferSchema: boolean
   [kInsertions]: number | undefined
   [kRemovals]: number | undefined
 }

--- a/packages/zbsearch/tests/inference.test.ts
+++ b/packages/zbsearch/tests/inference.test.ts
@@ -1,0 +1,274 @@
+import t from 'tap'
+import { create, insert, insertMultiple, load, save, search, update, upsert } from '../src/index.js'
+
+t.test('schema inference', async (t) => {
+  t.test('infers scalar, array, and nested types from inserted documents', async (t) => {
+    const db = create({})
+
+    await insert(db, {
+      title: 'The quick brown fox',
+      year: 2023,
+      active: true,
+      tags: ['fox', 'animal'],
+      ratings: [4, 5],
+      meta: { author: 'john' }
+    })
+    await insert(db, {
+      title: 'The lazy dog',
+      year: 2020,
+      active: false,
+      tags: ['dog'],
+      ratings: [3],
+      meta: { author: 'jane' }
+    })
+
+    t.strictSame(db.schema, {
+      title: 'string',
+      year: 'number',
+      active: 'boolean',
+      tags: 'string[]',
+      ratings: 'number[]',
+      meta: { author: 'string' }
+    })
+
+    const fulltext = await search(db, { term: 'fox' })
+    t.equal(fulltext.count, 1)
+    t.equal((fulltext.hits[0].document as any).title, 'The quick brown fox')
+
+    const filtered = await search(db, { term: '', where: { year: { gt: 2021 } } })
+    t.equal(filtered.count, 1)
+
+    const boolFiltered = await search(db, { term: '', where: { active: true } })
+    t.equal(boolFiltered.count, 1)
+
+    const arrFiltered = await search(db, { term: '', where: { tags: 'fox' } })
+    t.equal(arrFiltered.count, 1)
+
+    const nestedFiltered = await search(db, { term: '', where: { 'meta.author': 'john' } })
+    t.equal(nestedFiltered.count, 1)
+  })
+
+  t.test('supports sortBy, facets, and groupBy on inferred fields', async (t) => {
+    const db = create({})
+
+    await insertMultiple(db, [
+      { title: 'b doc', year: 2022 },
+      { title: 'a doc', year: 2020 },
+      { title: 'c doc', year: 2021 }
+    ])
+
+    const sorted = await search(db, { term: '', sortBy: { property: 'year', order: 'ASC' } })
+    t.strictSame(
+      sorted.hits.map((h) => (h.document as any).year),
+      [2020, 2021, 2022]
+    )
+
+    const sortedStr = await search(db, { term: '', sortBy: { property: 'title', order: 'ASC' } })
+    t.strictSame(
+      sortedStr.hits.map((h) => (h.document as any).title),
+      ['a doc', 'b doc', 'c doc']
+    )
+
+    const faceted = await search(db, {
+      term: 'doc',
+      facets: {
+        year: {
+          ranges: [
+            { from: 2019, to: 2020.5 },
+            { from: 2020.5, to: 2022.5 }
+          ]
+        }
+      }
+    })
+    t.ok(faceted.facets)
+    const bucketCounts = Object.values(faceted.facets!.year.values) as number[]
+    t.equal(bucketCounts.length, 2)
+    t.equal(
+      bucketCounts.reduce((a, b) => a + b, 0),
+      3
+    )
+
+    const grouped = await search(db, { term: 'doc', groupBy: { properties: ['year'] } })
+    t.equal(grouped.groups!.length, 3)
+  })
+
+  t.test('defers inference for empty arrays and null/undefined values', async (t) => {
+    const db = create({})
+
+    await insert(db, { title: 'first', tags: [], note: null })
+    t.strictSame(db.schema, { title: 'string' })
+
+    const before = await search(db, { term: 'first' })
+    t.equal(before.count, 1)
+
+    // Filtering on a not-yet-inferred property throws, as with any unknown property
+    try {
+      await search(db, { term: '', where: { tags: 'x' } })
+      t.fail('Should have thrown an error')
+    } catch (e) {
+      t.equal((e as any).code, 'UNKNOWN_FILTER_PROPERTY')
+    }
+
+    await insert(db, { title: 'second', tags: ['x'], note: 'now a string' })
+    t.strictSame(db.schema, { title: 'string', tags: 'string[]', note: 'string' })
+
+    const after = await search(db, { term: '', where: { tags: 'x' } })
+    t.equal(after.count, 1)
+  })
+
+  t.test('infers {lat, lon} objects as geopoints', async (t) => {
+    const db = create({})
+
+    await insert(db, { name: 'rome', location: { lat: 41.9028, lon: 12.4964 } })
+    await insert(db, { name: 'milan', location: { lat: 45.4642, lon: 9.19 } })
+    t.strictSame(db.schema, { name: 'string', location: 'geopoint' })
+
+    const result = await search(db, {
+      term: '',
+      where: { location: { radius: { coordinates: { lat: 41.9, lon: 12.5 }, value: 50, unit: 'km' } } }
+    })
+    t.equal(result.count, 1)
+    t.equal((result.hits[0].document as any).name, 'rome')
+  })
+
+  t.test('locks the type on first sight and rejects conflicting types', async (t) => {
+    const db = create({})
+
+    await insert(db, { title: 'first', year: 2023 })
+
+    try {
+      await insert(db, { title: 'second', year: 'not a number' })
+      t.fail('Should have thrown an error')
+    } catch (e) {
+      t.equal((e as any).code, 'SCHEMA_VALIDATION_FAILURE')
+    }
+
+    // The first document is still searchable, and the type is still number
+    const result = await search(db, { term: '', where: { year: { gt: 2000 } } })
+    t.equal(result.count, 1)
+    t.equal((db.schema as any).year, 'number')
+  })
+
+  t.test('infers new fields appearing mid-batch in insertMultiple', async (t) => {
+    const db = create({})
+
+    await insertMultiple(db, [{ a: 'first' }, { a: 'second', b: 42 }, { a: 'third', b: 7 }])
+
+    t.strictSame(db.schema, { a: 'string', b: 'number' })
+
+    const result = await search(db, { term: '', where: { b: { gt: 10 } } })
+    t.equal(result.count, 1)
+    t.equal((result.hits[0].document as any).a, 'second')
+  })
+
+  t.test('combines a declared vector field with inferred text fields', async (t) => {
+    const db = create({
+      schema: { embedding: 'vector[3]' },
+      inferSchema: true
+    })
+
+    await insert(db, { title: 'vector document', embedding: [1, 0, 0] })
+    await insert(db, { title: 'another document', embedding: [0, 1, 0] })
+
+    t.strictSame(db.schema, { embedding: 'vector[3]', title: 'string' })
+
+    const vectorResult = await search(db, {
+      mode: 'vector',
+      vector: { property: 'embedding', value: [1, 0, 0] }
+    })
+    // The orthogonal vector is below the default similarity threshold
+    t.equal(vectorResult.hits.length, 1)
+
+    const fulltextResult = await search(db, { term: 'vector' })
+    t.equal(fulltextResult.count, 1)
+
+    const hybridResult = await search(db, {
+      mode: 'hybrid',
+      term: 'vector',
+      vector: { property: 'embedding', value: [1, 0, 0] }
+    })
+    t.ok(hybridResult.hits.length >= 1)
+  })
+
+  t.test('keeps strict behavior when a schema is provided', async (t) => {
+    const db = create({
+      schema: { title: 'string' } as const
+    })
+
+    await insert(db, { title: 'hello world', extra: 'ignored' })
+
+    t.strictSame(db.schema, { title: 'string' })
+    t.notOk((db.data.index as any).indexes.extra)
+
+    const result = await search(db, { term: 'hello' })
+    t.equal(result.count, 1)
+  })
+
+  t.test('indexes nothing when inference is disabled and no schema is given', async (t) => {
+    const db = create({ inferSchema: false })
+
+    await insert(db, { title: 'nothing indexed' })
+
+    t.strictSame(db.schema, {})
+
+    const result = await search(db, { term: 'nothing' })
+    t.equal(result.count, 0)
+  })
+
+  t.test('preserves inferred fields across save/load and keeps inferring', async (t) => {
+    const db = create({})
+    await insert(db, { a: 'first', b: 42 })
+    await insert(db, { a: 'second', b: 7 })
+
+    const raw = await save(db)
+
+    const restored = create({})
+    await load(restored, raw)
+
+    const result = await search(restored, { term: '', where: { b: { gt: 10 } } })
+    t.equal(result.count, 1)
+
+    // Inference keeps working on the restored instance
+    await insert(restored, { a: 'third', c: true })
+    // Known fields are backfilled into the schema lazily, as documents
+    // carrying them arrive: "b" is only recorded once a doc contains it.
+    t.strictSame(restored.schema, { a: 'string', c: 'boolean' })
+
+    const newField = await search(restored, { term: '', where: { c: true } })
+    t.equal(newField.count, 1)
+
+    // Type conflicts are still rejected after a restore
+    try {
+      await insert(restored, { a: 'fourth', b: 'not a number' })
+      t.fail('Should have thrown an error')
+    } catch (e) {
+      t.equal((e as any).code, 'SCHEMA_VALIDATION_FAILURE')
+    }
+    t.equal((restored.schema as any).b, 'number')
+  })
+
+  t.test('infers new fields through update and upsert', async (t) => {
+    const db = create({})
+
+    const id = await insert(db, { title: 'original' })
+    await update(db, id, { title: 'updated', views: 10 })
+
+    t.strictSame(db.schema, { title: 'string', views: 'number' })
+    const afterUpdate = await search(db, { term: '', where: { views: { gte: 10 } } })
+    t.equal(afterUpdate.count, 1)
+
+    await upsert(db, { title: 'upserted', fresh: true })
+    t.strictSame(db.schema, { title: 'string', views: 'number', fresh: 'boolean' })
+
+    const afterUpsert = await search(db, { term: '', where: { fresh: true } })
+    t.equal(afterUpsert.count, 1)
+  })
+
+  t.test('skips the reserved __vector key and the document id', async (t) => {
+    const db = create({})
+
+    await insert(db, { id: 'doc-1', __vector: [1, 2, 3], title: 'hello' } as any)
+
+    t.strictSame(db.schema, { title: 'string' })
+  })
+})

--- a/packages/zbsearch/tests/inference.test.ts
+++ b/packages/zbsearch/tests/inference.test.ts
@@ -271,4 +271,77 @@ t.test('schema inference', async (t) => {
 
     t.strictSame(db.schema, { title: 'string' })
   })
+
+  t.test('rejects documents whose shape conflicts with a locked property path', async (t) => {
+    t.test('scalar first, then nested object at the same path', async (t) => {
+      const db = create({})
+
+      await insert(db, { a: 'scalar', keep: true })
+
+      try {
+        await insert(db, { a: { b: 1 } })
+        t.fail('Should have thrown an error')
+      } catch (e) {
+        t.equal((e as any).code, 'SCHEMA_VALIDATION_FAILURE')
+      }
+
+      // The schema is not corrupted by the rejected document
+      t.strictSame(db.schema, { a: 'string', keep: 'boolean' })
+      t.notOk((db.data.index as any).indexes['a.b'])
+
+      const result = await search(db, { term: 'scalar' })
+      t.equal(result.count, 1)
+    })
+
+    t.test('nested object first, then scalar at the parent path', async (t) => {
+      const db = create({})
+
+      await insert(db, { a: { b: 1 } })
+
+      try {
+        await insert(db, { a: 'scalar' })
+        t.fail('Should have thrown an error')
+      } catch (e) {
+        t.equal((e as any).code, 'SCHEMA_VALIDATION_FAILURE')
+      }
+
+      t.strictSame(db.schema, { a: { b: 'number' } })
+
+      const result = await search(db, { term: '', where: { 'a.b': { eq: 1 } } })
+      t.equal(result.count, 1)
+    })
+  })
+
+  t.test('respects unsortableProperties for inferred fields, across save/load', async (t) => {
+    const db = create({
+      sort: { unsortableProperties: ['b'] }
+    })
+
+    await insert(db, { a: 'first', b: 42 })
+
+    // "b" was inferred and indexed, but not made sortable
+    t.ok((db.data.index as any).indexes.b)
+    t.notOk((db.data.sorting as any).sorts.b)
+
+    const raw = await save(db)
+    const restored = create({})
+    await load(restored, raw)
+
+    // The deny list survives the round trip: new docs still can't sort by "b"
+    await insert(restored, { a: 'second', b: 7 })
+    t.notOk((restored.data.sorting as any).sorts.b)
+
+    try {
+      await search(restored, { term: '', sortBy: { property: 'b', order: 'ASC' } })
+      t.fail('Should have thrown an error')
+    } catch (e) {
+      t.equal((e as any).code, 'UNABLE_TO_SORT_ON_UNKNOWN_FIELD')
+    }
+
+    const result = await search(restored, { term: '', sortBy: { property: 'a', order: 'DESC' } })
+    t.strictSame(
+      result.hits.map((h) => (h.document as any).a),
+      ['second', 'first']
+    )
+  })
 })

--- a/packages/zbsearch/tests/type/inference.test-d.ts
+++ b/packages/zbsearch/tests/type/inference.test-d.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { expectAssignable, expectType } from 'tsd'
+import { create, insert, search } from '../../src/index.js'
+import type { Results, TypedDocument, ZBSearch } from '../../src/types.d.ts'
+
+// Schemaless usage: create() and create({}) are both allowed and return a
+// loosely-typed instance.
+const schemalessDB = create()
+const schemalessDB2 = create({})
+
+// insert accepts any document shape on a schemaless instance
+const idP = insert(schemalessDB, { anything: 'goes', nested: { deep: 1 }, list: [1, 2, 3] })
+expectType<string | Promise<string>>(idP)
+
+// search stays callable with free-form parameters, results keep their shape
+const resultP = search(schemalessDB, { term: 'anything' })
+expectAssignable<Results<unknown> | Promise<Results<unknown>>>(resultP)
+const result = resultP instanceof Promise ? await resultP : resultP
+expectAssignable<string | number>(result.hits[0].id)
+
+// Inference can be explicitly disabled
+const strictEmptyDB = create({ inferSchema: false })
+
+// Hybrid usage: declared (vector) fields keep their strong typing while
+// undeclared document fields are inferred at runtime.
+const hybridDB = create({
+  schema: { embedding: 'vector[3]' },
+  inferSchema: true
+})
+expectType<ZBSearch<{ embedding: 'vector[3]' }>>(hybridDB)
+
+const hybridIdP = insert(hybridDB, { embedding: [1, 0, 0], title: 'inferred at runtime' })
+expectType<string | Promise<string>>(hybridIdP)
+
+// A full schema without inference keeps the existing strict typing
+const movieSchema = { title: 'string', year: 'number' } as const
+const movieDB = create({ schema: movieSchema })
+expectType<ZBSearch<typeof movieSchema>>(movieDB)
+const movieResultP = search(movieDB, { term: 'godfather' })
+const movieResult = movieResultP instanceof Promise ? await movieResultP : movieResultP
+expectType<string>(movieResult.hits[0].document.title)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core insert/indexing and schema validation paths; incorrect inference or dynamic index registration could affect search correctness, though behavior is covered by new tests.
> 
> **Overview**
> **Schemaless indexes and optional schema inference** let you call `create()` without a `schema` (or with a partial schema plus `inferSchema: true`). On insert, new fields get types from first-seen values, index/sorter structures are registered dynamically, and `db.schema` grows; types lock afterward like a declared schema.
> 
> `create()` now takes optional `schema`, an `inferSchema` flag (on by default when no schema; strict when a schema is provided unless `inferSchema: true`), and stores `inferSchema` on the instance. **`inferSchemaFromDocument`** (new `inference.ts`) drives this from `insert` / `insertMultiple` (with cache refresh when batches discover new fields). Index and sorter setup use **`addSearchablePropertyToIndex`** and **`addSortablePropertyToSorter`** so properties can be added after creation; vectors and enums are never inferred.
> 
> **Edge**: `IndexMeta` / `CreateIndexInput` treat `schema` as optional; the index-builder CLI can `--create` without a schema file. **Docs** (README, `create.mdx`) describe inference rules, geopoint detection, and hybrid vector + inferred fields. Tests cover inference, persistence, and TypeScript for schemaless `create()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f889a5d202daad24034d0026f6d4cacb19da05ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->