### PR TITLE
Improves search quality and adds benchmarks

### DIFF
--- a/.github/workflows/benchmark-quality.yml
+++ b/.github/workflows/benchmark-quality.yml
@@ -1,0 +1,60 @@
+name: Search Quality Benchmarks (BEIR)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  search-quality:
+    name: Ranking quality on BEIR datasets
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install monorepo dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build packages used by benchmarks
+        run: |
+          pnpm --filter zbsearch build
+          pnpm --filter @zbsearch/plugin-qps build
+          pnpm --filter @zbsearch/plugin-pt15 build
+          pnpm --filter @zbsearch/stopwords build
+
+      - name: Install benchmark dependencies
+        working-directory: benchmarks
+        run: npm install
+
+      - name: Cache BEIR datasets
+        uses: actions/cache@v4
+        with:
+          path: benchmarks/.cache/beir
+          key: beir-datasets-scifact-nfcorpus-arguana-v1
+
+      - name: Run search-quality benchmarks
+        working-directory: benchmarks
+        run: node search-quality.js | tee search-quality-output.txt
+
+      - name: Write job summary
+        working-directory: benchmarks
+        run: grep -E '^(###|\|)' search-quality-output.txt >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload JSON results
+        uses: actions/upload-artifact@v4
+        with:
+          name: search-quality-benchmarks
+          path: benchmarks/benchmark/results/search-quality.json
+          if-no-files-found: warn

--- a/apps/docs/content/blog/deploying-zbsearch-to-cloudflare.mdx
+++ b/apps/docs/content/blog/deploying-zbsearch-to-cloudflare.mdx
@@ -61,9 +61,9 @@ flowchart TB
 
 | Path | What happens |
 | --- | --- |
-| **Write** | `IndexCoordinator` batches ops into WAL segments in R2 → `202 Accepted` |
+| **Write** | `IndexCoordinator` batches ops into WAL segments in R2 -> `202 Accepted` |
 | **Search** | Load live snapshot (3-layer cache); overlay pending WAL when `pendingOps > 0` |
-| **Rebuild** | Freeze WAL → merge → upload new immutable snapshot → promote `liveVersion` |
+| **Rebuild** | Freeze WAL -> merge -> upload new immutable snapshot -> promote `liveVersion` |
 | **Large indexes** | Create with `shards: N`; search fans out to `ShardSearch` DOs |
 
 ## Package split
@@ -103,7 +103,7 @@ Batch API writes (`POST .../documents/batch`) land in a **single segment**, cutt
 
 Search never re-decodes a snapshot on every request when it can avoid it:
 
-1. **Per-isolate LRU** - fully deserialized ZBSearch DBs (`SNAPSHOT_CACHE_MAX_ENTRIES` default 4, `SNAPSHOT_CACHE_MAX_BYTES` default ~64 MB). Rebuilds change the version key → natural invalidation.
+1. **Per-isolate LRU** - fully deserialized ZBSearch DBs (`SNAPSHOT_CACHE_MAX_ENTRIES` default 4, `SNAPSHOT_CACHE_MAX_BYTES` default ~64 MB). Rebuilds change the version key -> natural invalidation.
 2. **Workers Cache API** - raw snapshot bytes, shared per colo.
 3. **R2** - source of truth.
 
@@ -133,7 +133,7 @@ stateDiagram-v2
 
 1. Acquire rebuild lock on the coordinator  
 2. Freeze WAL (seal open segment, collect pending ops)  
-3. Merge snapshot + WAL → new msgpack snapshot  
+3. Merge snapshot + WAL -> new msgpack snapshot  
 4. Finalize: delete frozen segments, set `liveVersion`, release lock  
 
 Concurrent writes during rebuild survive as new `pendingOps`.
@@ -214,6 +214,6 @@ npx wrangler login
 npx zbsearch-edge-setup --init
 ```
 
-For production rebuilds: `@zbsearch/edge-index-builder@3.3.2` → `npx zbsearch-edge-builder rebuild --all` from CI.
+For production rebuilds: `@zbsearch/edge-index-builder@3.3.2` -> `npx zbsearch-edge-builder rebuild --all` from CI.
 
 See the [Cloudflare docs](/docs/cloudflare), [Indexing & rebuilds](/docs/cloudflare/indexing-and-rebuilds), and [Production](/docs/cloudflare/production) for operational detail.

--- a/apps/docs/content/docs/cloudflare/api-reference.mdx
+++ b/apps/docs/content/docs/cloudflare/api-reference.mdx
@@ -113,7 +113,7 @@ Create a new index.
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `name` | `string` | Yes | Display name; slugified to `id` (e.g. `"My Products"` → `my-products`) |
+| `name` | `string` | Yes | Display name; slugified to `id` (e.g. `"My Products"` -> `my-products`) |
 | `schema` | `object` | Yes | Same [schema types](/docs/zbsearch/usage/create) as standalone ZBSearch |
 | `settings` | `object` | No | See [index settings](#index-settings) |
 | `shards` | `number` | No | Create a **sharded index** with N physical shards (2–64). Fixed after creation - re-sharding means re-importing into a new index. |

--- a/apps/docs/content/docs/cloudflare/benchmarks.mdx
+++ b/apps/docs/content/docs/cloudflare/benchmarks.mdx
@@ -21,7 +21,7 @@ The monorepo ships an HTTP load-testing harness at [`benchmarks/http/`](https://
 | `k6/write.js` | Constant-rate batch upserts, tracks `pendingOps` drift |
 | `k6/mixed.js` | ~95% searches / ~5% batch writes on a shared ramp |
 | `k6/coldstart.js` | One search every 5s to observe cold vs warm latency |
-| `run.sh` | Orchestrator: generate corpus (if missing) → ingest → warm → search + mixed scenarios |
+| `run.sh` | Orchestrator: generate corpus (if missing) -> ingest -> warm -> search + mixed scenarios |
 
 All k6 scenarios read `BASE_URL` (required), `API_KEY`, and `INDEX_ID` (default `loadtest`) from the environment.
 
@@ -92,15 +92,15 @@ Measured with `wrangler dev` on an Apple Silicon laptop against the generated co
 
 | Scenario | Docs | Snapshot | Result |
 | --- | --- | --- | --- |
-| Search ramp 50→1000 req/s, clean index | 10,000 | 13.6 MB | ~470 req/s sustained avg; **med 1.1 ms, p95 16.5 ms, p99 &lt; 500 ms ✓**; 0.002% errors |
-| Search ramp, clean index, snapshot **larger than** `SNAPSHOT_CACHE_MAX_BYTES` (64 MB default) | 89,300 | 110 MB | **Collapse**: every request re-fetches + re-decodes the snapshot → 8.5 s avg latency, 99.96% errors |
+| Search ramp 50->1000 req/s, clean index | 10,000 | 13.6 MB | ~470 req/s sustained avg; **med 1.1 ms, p95 16.5 ms, p99 &lt; 500 ms ✓**; 0.002% errors |
+| Search ramp, clean index, snapshot **larger than** `SNAPSHOT_CACHE_MAX_BYTES` (64 MB default) | 89,300 | 110 MB | **Collapse**: every request re-fetches + re-decodes the snapshot -> 8.5 s avg latency, 99.96% errors |
 | Search ramp, clean index, cache budget raised to fit (250 MB) | 89,300 | 110 MB | **0% errors**, ~395 req/s avg; med 40.6 ms, p90 771 ms, p95 795 ms (single-process queuing at the top of the ramp) |
-| Mixed 95% search / 5% writes, index dirty | 89,300 | 110 MB | **Collapse**: with `pendingOps > 0` every search re-indexes all documents → ~8.5 s per search, 99.8% errors, writes time out behind searches |
+| Mixed 95% search / 5% writes, index dirty | 89,300 | 110 MB | **Collapse**: with `pendingOps > 0` every search re-indexes all documents -> ~8.5 s per search, 99.8% errors, writes time out behind searches |
 | Bulk ingest via API (`documents/batch`, 100/batch, concurrency 4) | 10,000 | - | ~1,590 docs/s, p99 batch latency 764 ms, 0 failed batches |
 | Bulk ingest via API, sustained (auto-rebuilds firing) | 100,000 | - | ~230 docs/s effective; ~11% batch 503s during in-Worker rebuild windows (local artifact - use the external builder for bulk loads) |
 | Bulk ingest via API into a **4-shard** index | 100,000 | 4× ~31 MB | ~615 docs/s (2.7× monolithic - writes parallelize across per-shard coordinators), 3.6% failed batches |
 | Group rebuild (all shards in parallel) | 96,400 | 124 MB total | ~6 s |
-| Search ramp 50→1000 req/s, 4-shard, clean | 96,400 | 4× ~31 MB | 99.1% success, ~243 req/s avg; **uncontended warm latency ~20 ms** (cold ~2.7 s = one-time load of 4 shard snapshots). Median under ramp ~1.5 s is single-process queueing: each request fans out to 4 shard searches in one local process - production isolates scale this horizontally |
+| Search ramp 50->1000 req/s, 4-shard, clean | 96,400 | 4× ~31 MB | 99.1% success, ~243 req/s avg; **uncontended warm latency ~20 ms** (cold ~2.7 s = one-time load of 4 shard snapshots). Median under ramp ~1.5 s is single-process queueing: each request fans out to 4 shard searches in one local process - production isolates scale this horizontally |
 | Mixed 95/5, 4-shard, dirty | 96,400 | - | Still collapses (99.8%): any dirty shard forces its full re-index per search (~2.6–3 s vs ~8.5 s monolithic - sharding divides the cost by shard count, but doesn't remove it). Keep `pendingOps` at zero with external rebuilds |
 
 Key takeaways:
@@ -120,7 +120,7 @@ Measured against a production Worker on the Workers Paid plan (k6 over a residen
 | Search ramp, clean index, 4 shards (in-process fan-out) | 10,000 (13.9 MB total) | 310,190 requests at ~470 req/s, **0.00% errors**; med 168 ms, p90 233 ms, p95 273 ms, max 16 s (cold isolates) |
 | Search ramp, clean index, 8 shards (`ShardSearch` DO fan-out), DOs cold | 100,000 (132 MB total) | 17,870 requests, 98.7% success (errors all in the initial cold window); med 292 ms, p90 411 ms, p95 502 ms, max 60 s (cold DO snapshot loads) |
 | Search ramp, same index, DOs warm | 100,000 (8× 16.5 MB) | 18,000 requests at 75 req/s for 4 min, **0.00% errors**; med 333 ms, p90 446 ms, p95 492 ms, max 2.7 s |
-| Single group search, cold → warm | 100,000 (8 shards) | 3.3 s cold → ~330-450 ms warm |
+| Single group search, cold -> warm | 100,000 (8 shards) | 3.3 s cold -> ~330-450 ms warm |
 | Bulk ingest via API (`documents/batch`, 100/batch) | 10,000 | ~75-80 docs/s sustained (concurrency 4), 0 failed batches; ~800 docs/s attempted at concurrency 16; threshold auto-rebuilds keep up |
 | Mixed 95% search / 5% writes, index dirty | 10,000 | **Collapse** (98.5% errors, med 3.2 s): the dirty-path re-index cost is the same as local - keep `pendingOps` at zero |
 | Same search load on the **Workers Free plan** | 10,000 | 97.8% of searches fail with error 1102 (10ms CPU cap) - [Workers Paid is required](/docs/cloudflare/production#cloudflare-plan-requirements) |
@@ -138,4 +138,4 @@ A manual-dispatch workflow at [`deploy/github-actions/zbsearch-loadtest.yml`](ht
 | `LOADTEST_BASE_URL` | Deployed Worker URL |
 | `LOADTEST_API_KEY` | API key for the target Worker |
 
-Dispatch it from **Actions → Loadtest → Run workflow**, picking the scenario (`search`, `write`, `mixed`, or `coldstart`) and the target `index_id` (must already exist and be ingested). The k6 JSON summary is uploaded as a build artifact (30-day retention).
+Dispatch it from **Actions -> Loadtest -> Run workflow**, picking the scenario (`search`, `write`, `mixed`, or `coldstart`) and the target `index_id` (must already exist and be ingested). The k6 JSON summary is uploaded as a build artifact (30-day retention).

--- a/apps/docs/content/docs/cloudflare/production.mdx
+++ b/apps/docs/content/docs/cloudflare/production.mdx
@@ -88,7 +88,7 @@ Copy it to `.github/workflows/zbsearch-rebuild.yml` in your fork or deployment r
 
 ### 2. Add repository secrets
 
-In GitHub → **Settings → Secrets and variables → Actions**, add:
+In GitHub -> **Settings -> Secrets and variables -> Actions**, add:
 
 | Secret | Value |
 | --- | --- |

--- a/apps/docs/content/docs/cloudflare/setup.mdx
+++ b/apps/docs/content/docs/cloudflare/setup.mdx
@@ -167,7 +167,7 @@ The Worker handles search and WAL writes. **Rebuilds** that merge the WAL into a
 
 Create a `.env` file in your project directory with your R2 credentials from the Cloudflare dashboard:
 
-1. Go to **R2 → Overview → Manage R2 API Tokens**
+1. Go to **R2 -> Overview -> Manage R2 API Tokens**
 2. Create a token with **Object Read & Write** on your bucket
 3. Copy the **Access Key ID**, **Secret Access Key**, and your **Account ID**
 

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,1 +1,2 @@
 benchmark
+.cache

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -126,7 +126,7 @@ Prints a Markdown table (P@10 / R@10 / MRR per language and config, plus a macro
 
 How to read it:
 
-- Queries run with stock `search(db, { term, limit: 10 })` defaults (exact token matching; prefix expansion is available as opt-in via `prefix: true` but is not used here). The morphology gap between configs comes from stem-level changes (umlauts, verb endings, articles) that plain tokenization cannot recover.
+- Queries run with stock `search(db, { term, limit: 10 })` defaults: **prefix matching is on** (search-as-you-type), with full-token matches scoring above prefix expansions. A query like `gato` still finds `gatos` in every config. The remaining morphology gap between configs comes from stem-level changes (umlauts, verb endings, articles) that prefix matching cannot recover.
 - **multilingual ≈ per-language** on exact-form queries, diacritic-dropped queries, and non-Latin scripts: Unicode-aware tokenization plus diacritic folding covers those cases without any configuration.
 - **multilingual < per-language** on inflection/morphology queries: the tuned configs stem (e.g. `running` -> `run`, `Häuser` -> `haus`) and drop stopwords, the zero-config mode does not.
 - **multilingual ≫ english-default** on Russian and Arabic: the default English splitter discards non-Latin characters entirely, so recall collapses there. The runner prints a loud warning if multilingual ever scores *below* english-default on those two languages, which would indicate a tokenizer bug rather than a trade-off.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -29,7 +29,7 @@ node compare.js --quick
 
 ### GitHub Actions
 
-Run **Orama vs ZBSearch Benchmarks** via `workflow_dispatch` (Actions → workflow → Run workflow).
+Run **Orama vs ZBSearch Benchmarks** via `workflow_dispatch` (Actions -> workflow -> Run workflow).
 
 The job prints Markdown + ASCII tables in the log, writes the Markdown table to the job summary, and uploads `orama-vs-zbsearch.json` as an artifact.
 
@@ -72,6 +72,40 @@ Fork PRs are supported: benchmarks run on `pull_request` (read-only token), and 
 | `npm run benchmark:memory` | Memory footprint |
 | `npm run benchmark:bundle-size` | Serialized index size |
 | `npm run benchmark:algorithms` | BM25 / QPS / PT15 |
+| `npm run benchmark:search-quality` | Standardized ranking quality on BEIR datasets (nDCG@10 / MAP@100 / R@100) |
+
+## Standardized search quality (BEIR)
+
+Measures **ranking quality** (not throughput) of every engine on standard [BEIR](https://github.com/beir-cellar/beir) test collections with official relevance judgments (qrels):
+
+| Dataset | Documents | Test queries | Qrels |
+| --- | --- | --- | --- |
+| SciFact | 5,183 | 300 | binary |
+| NFCorpus | 3,633 | 323 | graded (1–2) |
+| ArguAna | 8,674 | 1,406 | binary (1 relevant per query) |
+
+Datasets are downloaded on first run from the official BEIR hosting and cached under `.cache/beir/` (gitignored — the datasets carry per-dataset licenses, e.g. SciFact is CC BY-NC 2.0, so they are never committed).
+
+```sh
+# From repo root
+pnpm --filter zbsearch build
+pnpm --filter @zbsearch/plugin-qps build
+pnpm --filter @zbsearch/plugin-pt15 build
+pnpm --filter @zbsearch/stemmers build
+pnpm --filter @zbsearch/stopwords build
+
+cd benchmarks
+npm install
+npm run benchmark:search-quality   # full run (3 datasets × 8 engines)
+npm run test:search-quality        # unit tests for the metric implementations
+```
+
+Reports **nDCG@10** (BEIR's primary metric), **MAP@100**, **Recall@100**, **P@10**, and **MRR@10** per dataset and engine, plus a macro average — alongside speed insights: **index build time** and **per-query latency** for the same runs. Each engine has a **5-minute query budget per dataset**; an engine that exceeds it is marked **crashed (†)** and scores 0 — an engine that cannot answer the dataset's queries in time has effectively failed the run. Metrics are reimplemented in `src/search-quality/metrics.js` with exact [trec_eval](https://github.com/usnistgov/trec_eval) semantics (linear-gain nDCG, `map_cut` denominators) — the same definitions BEIR reports via pytrec_eval. Full per-query results (including timings) are written incrementally to `benchmark/results/search-quality.json` after every dataset.
+
+How to read it:
+
+- Every engine runs in its **best relevance configuration using only features its own ecosystem ships** — nothing is bolted on from outside: ZBSearch (with English stopwords + Porter stemmer and `prefix: false` for Lucene-style exact token matching; its default prefix expansion is a search-as-you-type feature), Orama (stopwords + stemmer from the official `@orama/*` packages; its `exact: true` applies a case-sensitive verbatim post-filter and cannot do exact token matching, so it runs with its default behavior), Lunr runs its full default pipeline (trimmer/stopwords/stemmer), FlexSearch uses its relevance-oriented `score` preset with OR token combination, and MiniSearch — which ships no stemmer or stopword list — runs with plain default tokenization. Fuse.js runs with threshold 0 (exact substring match): its fuzzy mode (threshold 0.3) is a full-corpus scan per query (~39 s/query on ArguAna, ~15 h for the dataset) and is unusable at this scale — the runner repeats this caveat under every table. See `src/search-quality/engines.js` for the exact configurations.
+- Tables print the published Lucene BM25 nDCG@10 from the BEIR paper (SciFact 0.665, NFCorpus 0.325, ArguAna 0.414) as a reference point. Analyzer differences (stemming, BM25 parameters) legitimately cost several points; the runner only warns if ZBSearch (BM25) lands more than 0.15 below the reference, which indicates a harness bug rather than a quality trade-off.
 
 ## Multilingual search quality
 
@@ -92,9 +126,9 @@ Prints a Markdown table (P@10 / R@10 / MRR per language and config, plus a macro
 
 How to read it:
 
-- Queries run with stock `search(db, { term, limit: 10 })` defaults, which include **prefix matching**: a query like `gato` still finds `gatos` in every config. The remaining morphology gap comes from stem-level changes (umlauts, verb endings, articles) that prefix matching cannot recover.
+- Queries run with stock `search(db, { term, limit: 10 })` defaults (exact token matching; prefix expansion is available as opt-in via `prefix: true` but is not used here). The morphology gap between configs comes from stem-level changes (umlauts, verb endings, articles) that plain tokenization cannot recover.
 - **multilingual ≈ per-language** on exact-form queries, diacritic-dropped queries, and non-Latin scripts: Unicode-aware tokenization plus diacritic folding covers those cases without any configuration.
-- **multilingual < per-language** on inflection/morphology queries: the tuned configs stem (e.g. `running` → `run`, `Häuser` → `haus`) and drop stopwords, the zero-config mode does not.
+- **multilingual < per-language** on inflection/morphology queries: the tuned configs stem (e.g. `running` -> `run`, `Häuser` -> `haus`) and drop stopwords, the zero-config mode does not.
 - **multilingual ≫ english-default** on Russian and Arabic: the default English splitter discards non-Latin characters entirely, so recall collapses there. The runner prints a loud warning if multilingual ever scores *below* english-default on those two languages, which would indicate a tokenizer bug rather than a trade-off.
-- Diacritic folding covers Latin scripts plus Cyrillic `ё`→`е` and Arabic alef variants (`آ`/`أ`/`إ`/`ٱ`→`ا`, `ى`→`ي`), and folding runs *before* stemming so accented and unaccented surface forms of a word share a stem (e.g. Portuguese `pão`/`pao`). The residual Arabic gap vs per-language comes from the Arabic stemmer itself (weak on bare forms and verb prefixes), not from tokenization.
+- Diacritic folding covers Latin scripts plus Cyrillic `ё`->`е` and Arabic alef variants (`آ`/`أ`/`إ`/`ٱ`->`ا`, `ى`->`ي`), and folding runs *before* stemming so accented and unaccented surface forms of a word share a stem (e.g. Portuguese `pão`/`pao`). The residual Arabic gap vs per-language comes from the Arabic stemmer itself (weak on bare forms and verb prefixes), not from tokenization.
 

--- a/benchmarks/package-lock.json
+++ b/benchmarks/package-lock.json
@@ -10,6 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@orama/orama": "^3.1.18",
+        "@orama/stemmers": "^3.1.18",
+        "@orama/stopwords": "^3.1.18",
         "@zbsearch/plugin-pt15": "file:../packages/plugin-pt15",
         "@zbsearch/plugin-qps": "file:../packages/plugin-qps",
         "@zbsearch/stemmers": "file:../packages/stemmers",
@@ -1368,6 +1370,24 @@
       "version": "3.1.18",
       "resolved": "https://registry.npmjs.org/@orama/orama/-/orama-3.1.18.tgz",
       "integrity": "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
+    "node_modules/@orama/stemmers": {
+      "version": "3.1.18",
+      "resolved": "https://registry.npmjs.org/@orama/stemmers/-/stemmers-3.1.18.tgz",
+      "integrity": "sha512-xXs5fpiUvBs4jJZtnayJmUSomdxxiwwwvTbAzPHSyI6geLM7bxXHgpVlYz4JeMBycHX8bHF7j9m7F35BxhuZ8g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
+    "node_modules/@orama/stopwords": {
+      "version": "3.1.18",
+      "resolved": "https://registry.npmjs.org/@orama/stopwords/-/stopwords-3.1.18.tgz",
+      "integrity": "sha512-W8V7m7RnCme+99OmKl/xs5rf6OUhFpr0aPGVmPrXzTLSg4ZqSbRY2euS2S/lgjjYi/0NhEWqwoq8nDY6Ihx4EA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20.0.0"

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -18,13 +18,17 @@
     "benchmark:vector-ivf": "node vector-ivf.js",
     "benchmark:bundle-size": "node bundle-size.js",
     "benchmark:memory": "node memory.js",
-    "benchmark:multilingual-quality": "node multilingual-quality.js"
+    "benchmark:multilingual-quality": "node multilingual-quality.js",
+    "benchmark:search-quality": "node search-quality.js",
+    "test:search-quality": "node --test \"src/search-quality/*.test.js\""
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "@orama/orama": "^3.1.18",
+    "@orama/stemmers": "^3.1.18",
+    "@orama/stopwords": "^3.1.18",
     "@zbsearch/plugin-pt15": "file:../packages/plugin-pt15",
     "@zbsearch/plugin-qps": "file:../packages/plugin-qps",
     "@zbsearch/stemmers": "file:../packages/stemmers",

--- a/benchmarks/search-quality.js
+++ b/benchmarks/search-quality.js
@@ -1,0 +1,193 @@
+// Standardized search-quality benchmark: every engine is run against official
+// BEIR test collections (corpus + queries + qrels) and scored with
+// trec_eval-compatible metrics.
+//
+// Datasets (downloaded on first run into .cache/beir/, see src/search-quality/datasets.js):
+//   scifact   5,183 docs / 300 test queries / binary qrels
+//   nfcorpus  3,633 docs / 323 test queries / graded qrels (1-2)
+//   arguana   8,674 docs / 1,406 test queries / binary qrels (1 relevant per query)
+//
+// Metrics (per query, then averaged): nDCG@10 (BEIR's primary metric), MAP@100,
+// Recall@100, P@10, MRR@10. See src/search-quality/metrics.js for exact semantics.
+//
+// As a sanity guard, ZBSearch (BM25) nDCG@10 is compared against the published
+// Lucene BM25 baselines from the BEIR paper (multifield, title + text): landing
+// far below them indicates a bug in the harness, not a quality trade-off.
+//
+// Run with: npm run benchmark:search-quality
+
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { DATASETS, loadDataset } from './src/search-quality/datasets.js'
+import { engines, FUSE_NOTE } from './src/search-quality/engines.js'
+import { evaluateRun } from './src/search-quality/metrics.js'
+
+const RETRIEVAL_LIMIT = 100
+
+// Per-engine time budget for a dataset's query loop. An engine that exceeds it
+// is marked as crashed and scores 0: a search engine that cannot answer the
+// dataset's queries within the budget has effectively failed the run.
+// (Fuse.js completes SciFact/NFCorpus in ~2 min but needs ~45 min on ArguAna.)
+const ENGINE_BUDGET_MS = 5 * 60 * 1000
+
+// Published BM25 (Lucene, multifield) nDCG@10 from the BEIR paper / Pyserini 2CR.
+const BM25_REFERENCE_NDCG10 = {
+  scifact: 0.665,
+  nfcorpus: 0.325,
+  arguana: 0.414
+}
+// The tolerance is deliberately wide: tokenizer/analyzer differences (stemming, stopwords, BM25 parameters) legitimately cost several nDCG points vs Lucene.
+// This guard only exists to catch catastrophic harness bugs (e.g. broken id mapping or search parameters that silently return nothing).
+const SANITY_TOLERANCE = 0.15
+
+const RESULTS_FILE = path.join(path.dirname(fileURLToPath(import.meta.url)), 'benchmark', 'results', 'search-quality.json')
+
+function fmt(value) {
+  return value.toFixed(3)
+}
+
+function printDatasetTable(datasetName, rows) {
+  const reference = BM25_REFERENCE_NDCG10[datasetName]
+  console.log(`\n### ${datasetName} — nDCG@10 / MAP@100 / R@100 / P@10 / MRR@10 (reference Lucene BM25 nDCG@10: ${reference})\n`)
+  console.log('| Engine | nDCG@10 | MAP@100 | R@100 | P@10 | MRR@10 | Build (s) | ms/query |')
+  console.log('|---|---|---|---|---|---|---|---|')
+  for (const { label, metrics, timing } of rows) {
+    const tag = timing.crashed ? ' †' : ''
+    const msPerQuery = timing.crashed ? 'crashed' : timing.msPerQuery.toFixed(1)
+    console.log(
+      `| ${label}${tag} | ${fmt(metrics.ndcg10)} | ${fmt(metrics.map100)} | ${fmt(metrics.recall100)} | ${fmt(metrics.precision10)} | ${fmt(metrics.mrr10)} | ${timing.buildSeconds.toFixed(1)} | ${msPerQuery} |`
+    )
+  }
+  console.log('')
+  if (rows.some(({ timing }) => timing.crashed)) {
+    console.log(`† crashed = exceeded the ${(ENGINE_BUDGET_MS / 1000).toFixed(0)} s per-engine query budget; scored 0.`)
+    console.log('')
+  }
+  console.log(FUSE_NOTE)
+  console.log('')
+}
+
+function printMacroTable(perDatasetRows) {
+  console.log('\n### Macro average across datasets\n')
+  console.log('| Engine | nDCG@10 | MAP@100 | R@100 | P@10 | MRR@10 | ms/query |')
+  console.log('|---|---|---|---|---|---|---|')
+  for (const { key, label } of engines) {
+    const sums = { ndcg10: 0, map100: 0, recall100: 0, precision10: 0, mrr10: 0 }
+    let totalQueryMs = 0
+    let totalQueries = 0
+    for (const rows of Object.values(perDatasetRows)) {
+      const row = rows.find((r) => r.key === key)
+      for (const metric of Object.keys(sums)) {
+        sums[metric] += row.metrics[metric]
+      }
+      if (row.timing.msPerQuery !== null) {
+        totalQueryMs += row.timing.msPerQuery * row.timing.queries
+        totalQueries += row.timing.queries
+      }
+    }
+    const n = Object.keys(perDatasetRows).length
+    const msPerQuery = totalQueries > 0 ? (totalQueryMs / totalQueries).toFixed(1) : 'crashed'
+    console.log(
+      `| ${label} | ${fmt(sums.ndcg10 / n)} | ${fmt(sums.map100 / n)} | ${fmt(sums.recall100 / n)} | ${fmt(sums.precision10 / n)} | ${fmt(sums.mrr10 / n)} | ${msPerQuery} |`
+    )
+  }
+  console.log('')
+}
+
+const report = {
+  description: 'Search quality on BEIR test collections (scifact, nfcorpus, arguana) with trec_eval-compatible metrics',
+  metrics: {
+    ndcg10: 'trec_eval ndcg_cut.10: linear gain, DCG = sum(rel_i / log2(i + 1)) / IDCG',
+    map100: 'trec_eval map_cut.100: AP@100 averaged, denominator = all relevant docs in qrels',
+    recall100: 'trec_eval recall.100',
+    precision10: 'trec_eval P.10',
+    mrr10: 'BEIR custom MRR@10: 1/rank of first relevant hit within top 10'
+  },
+  retrievalLimit: RETRIEVAL_LIMIT,
+  notes: [FUSE_NOTE],
+  datasets: {}
+}
+
+const perDatasetRows = {}
+const warnings = []
+
+// Write the report after every dataset so a crash or timeout never loses
+// completed work (Fuse.js makes full runs long).
+async function writeReport() {
+  report.warnings = warnings
+  await mkdir(path.dirname(RESULTS_FILE), { recursive: true })
+  await writeFile(RESULTS_FILE, JSON.stringify(report, null, 2))
+}
+
+for (const datasetName of Object.keys(DATASETS)) {
+  const { documents, queries, qrels } = await loadDataset(datasetName)
+  console.log(`\n${datasetName}: ${documents.length} documents, ${queries.length} judged queries`)
+
+  const rows = []
+  for (const { key, label, build, search } of engines) {
+    const buildStart = performance.now()
+    const engine = await build(documents)
+    const buildSeconds = (performance.now() - buildStart) / 1000
+
+    const queryStart = performance.now()
+    const runs = new Map()
+    const details = []
+    let crashed = false
+
+    for (const { id, text } of queries) {
+      if (performance.now() - queryStart > ENGINE_BUDGET_MS) {
+        crashed = true
+        break
+      }
+      const hits = await search(engine, text, RETRIEVAL_LIMIT)
+      runs.set(id, hits)
+      details.push({ queryId: id, term: text, hits: hits.slice(0, 10) })
+    }
+    const queryMs = performance.now() - queryStart
+
+    const metrics = crashed ? { ndcg10: 0, map100: 0, recall100: 0, precision10: 0, mrr10: 0 } : evaluateRun(runs, qrels)
+    const timing = { buildSeconds, msPerQuery: crashed ? null : queryMs / queries.length, queries: queries.length, crashed }
+    rows.push({ key, label, metrics, timing, queries: details })
+    console.log(
+      crashed
+        ? `  ${label}: CRASHED (exceeded ${(ENGINE_BUDGET_MS / 1000).toFixed(0)}s query budget) — scored 0`
+        : `  ${label}: nDCG@10 ${fmt(metrics.ndcg10)}  MAP@100 ${fmt(metrics.map100)}  R@100 ${fmt(metrics.recall100)}  (build ${buildSeconds.toFixed(1)}s, ${timing.msPerQuery.toFixed(1)} ms/query)`
+    )
+  }
+
+  perDatasetRows[datasetName] = rows
+  printDatasetTable(datasetName, rows)
+
+  const zbsearchBm25 = rows.find((row) => row.key === 'zbsearch-bm25').metrics
+  const reference = BM25_REFERENCE_NDCG10[datasetName]
+  if (zbsearchBm25.ndcg10 < reference - SANITY_TOLERANCE) {
+    warnings.push(
+      `*** WARNING: ZBSearch (BM25) nDCG@10 on ${datasetName} (${fmt(zbsearchBm25.ndcg10)}) is more than ${SANITY_TOLERANCE} below the published Lucene BM25 baseline (${reference}). This suggests a harness bug, not a quality trade-off. ***`
+    )
+  }
+
+  report.datasets[datasetName] = {
+    documents: documents.length,
+    queries: queries.length,
+    referenceBm25Ndcg10: reference,
+    engines: Object.fromEntries(
+      rows.map(({ key, label, metrics, timing, queries: details }) => [key, { label, ...metrics, timing, queries: details }])
+    )
+  }
+
+  await writeReport()
+  console.log(`  (partial results written to ${path.relative(process.cwd(), RESULTS_FILE)})`)
+}
+
+printMacroTable(perDatasetRows)
+
+for (const warning of warnings) {
+  console.log(warning)
+}
+if (warnings.length > 0) {
+  console.log('')
+}
+
+await writeReport()
+console.log(`Full results written to ${path.relative(process.cwd(), RESULTS_FILE)}`)

--- a/benchmarks/src/search-quality/datasets.js
+++ b/benchmarks/src/search-quality/datasets.js
@@ -1,0 +1,116 @@
+// BEIR dataset download, cache, and parsing.
+//
+// Datasets are fetched on demand from the official BEIR hosting
+// (https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/{name}.zip)
+// and extracted into benchmarks/.cache/beir/{name}/. Each zip contains:
+//
+//   {name}/corpus.jsonl      {"_id": ..., "title": ..., "text": ...}
+//   {name}/queries.jsonl     {"_id": ..., "text": ...}
+//   {name}/qrels/test.tsv    "query-id\tcorpus-id\tscore" (header row, int score)
+//
+// Nothing is committed to the repo: BEIR datasets carry per-dataset licenses
+// (e.g. SciFact is CC BY-NC 2.0), so they are downloaded on first use.
+
+import { createReadStream } from 'node:fs'
+import { mkdir, stat, writeFile } from 'node:fs/promises'
+import { createInterface } from 'node:readline'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const execFileAsync = promisify(execFile)
+
+const CACHE_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '.cache', 'beir')
+const BASE_URL = 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets'
+
+export const DATASETS = {
+  scifact: { documents: 5183, queries: 300 },
+  nfcorpus: { documents: 3633, queries: 323 },
+  arguana: { documents: 8674, queries: 1406 }
+}
+
+async function exists(filePath) {
+  try {
+    await stat(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function* readJsonl(filePath) {
+  const lines = createInterface({ input: createReadStream(filePath, 'utf8'), crlfDelay: Infinity })
+  for await (const line of lines) {
+    if (line.trim().length > 0) {
+      yield JSON.parse(line)
+    }
+  }
+}
+
+async function ensureDataset(name) {
+  const dir = path.join(CACHE_DIR, name)
+  if (await exists(path.join(dir, 'corpus.jsonl'))) {
+    return dir
+  }
+
+  await mkdir(CACHE_DIR, { recursive: true })
+  const zipPath = path.join(CACHE_DIR, `${name}.zip`)
+
+  if (!(await exists(zipPath))) {
+    const url = `${BASE_URL}/${name}.zip`
+    console.log(`Downloading ${url} ...`)
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Failed to download ${url}: HTTP ${response.status}`)
+    }
+    await writeFile(zipPath, Buffer.from(await response.arrayBuffer()))
+  }
+
+  try {
+    await execFileAsync('unzip', ['-o', '-q', zipPath, '-d', CACHE_DIR])
+  } catch (error) {
+    throw new Error(`Failed to extract ${zipPath} — is the "unzip" command available? (${error.message})`)
+  }
+
+  return dir
+}
+
+// Loads a BEIR dataset into:
+//   documents: [{ id, text }]   (title and text concatenated, BEIR "multifield" style)
+//   queries:   [{ id, text }]   (only queries judged in qrels/test.tsv)
+//   qrels:     Map<queryId, Map<docId, score>>
+export async function loadDataset(name) {
+  const dir = await ensureDataset(name)
+
+  const qrels = new Map()
+  const tsvLines = createInterface({ input: createReadStream(path.join(dir, 'qrels', 'test.tsv'), 'utf8'), crlfDelay: Infinity })
+  let isHeader = true
+  for await (const line of tsvLines) {
+    if (isHeader) {
+      isHeader = false
+      continue
+    }
+    const [queryId, docId, score] = line.split('\t')
+    if (!qrels.has(queryId)) {
+      qrels.set(queryId, new Map())
+    }
+    qrels.get(queryId).set(docId, Number(score))
+  }
+
+  const documents = []
+  for await (const record of readJsonl(path.join(dir, 'corpus.jsonl'))) {
+    const title = record.title ? `${record.title} ` : ''
+    documents.push({ id: String(record._id), text: `${title}${record.text ?? ''}` })
+  }
+
+  const queries = []
+  for await (const record of readJsonl(path.join(dir, 'queries.jsonl'))) {
+    const id = String(record._id)
+    if (qrels.has(id)) {
+      queries.push({ id, text: record.text })
+    }
+  }
+
+  return { name, documents, queries, qrels }
+}

--- a/benchmarks/src/search-quality/engines.js
+++ b/benchmarks/src/search-quality/engines.js
@@ -1,0 +1,231 @@
+// Engine adapters for the search-quality benchmark.
+//
+// Each adapter has the shape:
+//   { key, label, build(docs) → engine, search(engine, term, limit) → string[] }
+// where `docs` is [{ id, text }] with the BEIR corpus ids, and `search` returns
+// corpus ids ranked best-first.
+//
+// Every engine is configured for its BEST relevance using only the features
+// its own ecosystem provides — nothing is bolted on from outside:
+//   - ZBSearch / Orama: English stopwords + Porter stemmer from their official
+//     packages (@zbsearch/stemmers+stopwords, @orama/stemmers+stopwords).
+//   - MiniSearch: ships no stemmer/stopwords → plain default tokenization.
+//   - FlexSearch: ships no stemmer/stopwords → `score` preset (its
+//     relevance-oriented preset), raw query tokens.
+//   - Lunr: full default pipeline (it ships a trimmer, stopword filter and
+//     stemmer).
+//   - Fuse.js: threshold 0 (exact substring) — its fuzzy mode is unusably
+//     slow at BEIR scale; see FUSE_NOTE below.
+//
+// ZBSearch runs with `prefix: false` and Orama with `exact: true`: Lucene-style
+// exact token matching, the right mode for full-text relevance evaluation
+// (ZBSearch's default prefix expansion is a search-as-you-type feature).
+
+import FlexSearch from 'flexsearch'
+import Fuse from 'fuse.js'
+import lunr from 'lunr'
+import MiniSearch from 'minisearch'
+import * as orama from '@orama/orama'
+import { stemmer as oramaStemmer } from '@orama/stemmers/english'
+import { stopwords as oramaStopwords } from '@orama/stopwords/english'
+import * as zbsearch from 'zbsearch'
+import { pluginPT15 } from '@zbsearch/plugin-pt15'
+import { pluginQPS } from '@zbsearch/plugin-qps'
+import { stemmer as zbsearchStemmer } from '@zbsearch/stemmers/english'
+import { stopwords as zbsearchStopwords } from '@zbsearch/stopwords/english'
+
+const schema = { text: 'string' }
+
+// insertMultiple returns generated ids in insertion order; zip them with the corpus ids so hits can be mapped back (same trick as multilingual-quality.js).
+async function buildOramaLike(engine, docs, tokenizer, plugins = []) {
+  const db = engine.create({ schema, plugins, components: { tokenizer } })
+  const generatedIds = await engine.insertMultiple(db, docs)
+  const corpusIdByGenerated = new Map(generatedIds.map((generated, i) => [String(generated), docs[i].id]))
+  return { db, corpusIdByGenerated }
+}
+
+async function searchOramaLike(engine, { db, corpusIdByGenerated }, term, limit, extraParams = {}) {
+  const results = await engine.search(db, { term, limit, ...extraParams })
+  return results.hits.map((hit) => corpusIdByGenerated.get(String(hit.id)))
+}
+
+const zbsearchTokenizer = {
+  language: 'english',
+  stemmer: zbsearchStemmer,
+  stopWords: zbsearchStopwords,
+  // Keep duplicate tokens so the index stores real term frequencies for BM25.
+  allowDuplicates: true
+}
+
+const oramaTokenizer = {
+  language: 'english',
+  stemmer: oramaStemmer,
+  stopWords: oramaStopwords
+}
+
+function buildZbsearch(plugins = []) {
+  return (docs) => buildOramaLike(zbsearch, docs, zbsearchTokenizer, plugins)
+}
+
+function searchZbsearch(engineState, term, limit) {
+  // Lucene-style exact token matching for the benchmark (prefix expansion is
+  // ZBSearch's default for search-as-you-type; `prefix: false` disables it).
+  return searchOramaLike(zbsearch, engineState, term, limit, { prefix: false })
+}
+
+// FlexSearch's `score` preset is its relevance-oriented configuration (per-field scoring, strict tokenization, no partial-match noise).
+function buildFlexSearch(docs) {
+  const index = new FlexSearch.Document({
+    preset: 'score',
+    document: { id: 'id', index: ['text'] }
+  })
+  for (const doc of docs) {
+    index.add(doc)
+  }
+  return index
+}
+
+// This FlexSearch version intersects query tokens (AND) and ignores `bool`, so
+// OR semantics are emulated: search each token separately and union the matches
+// in first-seen rank order. No stopword removal or stemming — FlexSearch ships
+// none, so it is tested on raw tokens.
+function searchFlexSearch(index, term, limit) {
+  const ranked = []
+  const seen = new Set()
+  for (const token of term.toLowerCase().split(/\s+/)) {
+    if (!token) {
+      continue
+    }
+    for (const { result } of index.search(token, { limit })) {
+      for (const id of result) {
+        if (!seen.has(id)) {
+          seen.add(id)
+          ranked.push(id)
+          if (ranked.length >= limit) {
+            return ranked
+          }
+        }
+      }
+    }
+  }
+
+  return ranked
+}
+
+// MiniSearch ships no stemmer or stopword list, so it runs with its default tokenization (lowercasing) and default OR term combination.
+function buildMiniSearch(docs) {
+  const index = new MiniSearch({ fields: ['text'] })
+  index.addAll(docs)
+  return index
+}
+
+function searchMiniSearch(index, term, limit) {
+  return index.search(term).slice(0, limit).map((hit) => hit.id)
+}
+
+// Fuse.js runs with threshold 0 (exact substring matching). Its fuzzy mode
+// (threshold 0.3, ignoreLocation) is a full bitap scan of every document per
+// query — measured at ~39 s/query on ArguAna (~15 h for the dataset) — which
+// makes fuzzy Fuse unusable at BEIR scale. The runner prints FUSE_NOTE under
+// every table so the reported numbers are read with this caveat.
+function buildFuse(docs) {
+  return new Fuse(docs, {
+    keys: ['text'],
+    threshold: 0,
+    ignoreLocation: true,
+    includeScore: false
+  })
+}
+
+function searchFuse(index, term, limit) {
+  return index.search(term, { limit }).map(({ item }) => item.id)
+}
+
+export const FUSE_NOTE =
+  'Note: Fuse.js runs with threshold 0 (exact substring match). Its fuzzy mode (threshold 0.3) costs ~39 s/query on ArguAna (~15 h for the dataset) and is unusable at this scale.'
+
+// Lunr's full default pipeline (trimmer + stopWordFilter + stemmer) is its best relevance configuration.
+function buildLunr(docs) {
+  return lunr(function () {
+    this.ref('id')
+    this.field('text')
+    for (const doc of docs) {
+      this.add(doc)
+    }
+  })
+}
+
+// index.search() runs the full search pipeline (trimmer, stopword removal, stemming) but its query-string parser reserves some characters (:, ~, ^, *, leading +/-).
+// Strip them from the raw BEIR query text; if parsing still fails, the query counts as an empty run.
+function searchLunr(index, term, limit) {
+  const sanitized = term
+    .replace(/[:~^*]/g, ' ')
+    .split(/\s+/)
+    .map((token) => token.replace(/^[+-]+/, ''))
+    .filter((token) => token.length > 0)
+    .join(' ')
+  if (sanitized.length === 0) {
+    return []
+  }
+
+  try {
+    return index.search(sanitized).slice(0, limit).map(({ ref }) => ref)
+  } catch {
+    return []
+  }
+}
+
+export const engines = [
+  {
+    key: 'zbsearch-bm25',
+    label: 'ZBSearch (BM25)',
+    build: buildZbsearch(),
+    search: searchZbsearch
+  },
+  {
+    key: 'zbsearch-qps',
+    label: 'ZBSearch (QPS)',
+    build: buildZbsearch([pluginQPS()]),
+    search: searchZbsearch
+  },
+  {
+    key: 'zbsearch-pt15',
+    label: 'ZBSearch (PT15)',
+    build: buildZbsearch([pluginPT15()]),
+    search: searchZbsearch
+  },
+  {
+    key: 'orama',
+    label: 'Orama',
+    build: (docs) => buildOramaLike(orama, docs, oramaTokenizer),
+    // Orama runs with its default behavior (prefix expansion): its exact: true
+    // applies a case-sensitive verbatim post-filter requiring ALL query terms in
+    // the raw text (issue-866 feature), which returns zero hits for
+    // natural-language queries — it cannot do Lucene-style exact token matching.
+    search: (engineState, term, limit) => searchOramaLike(orama, engineState, term, limit)
+  },
+  {
+    key: 'minisearch',
+    label: 'MiniSearch',
+    build: buildMiniSearch,
+    search: searchMiniSearch
+  },
+  {
+    key: 'flexsearch',
+    label: 'FlexSearch',
+    build: buildFlexSearch,
+    search: searchFlexSearch
+  },
+  {
+    key: 'lunr',
+    label: 'Lunr',
+    build: buildLunr,
+    search: searchLunr
+  },
+  {
+    key: 'fusejs',
+    label: 'Fuse.js',
+    build: buildFuse,
+    search: searchFuse
+  }
+]

--- a/benchmarks/src/search-quality/metrics.js
+++ b/benchmarks/src/search-quality/metrics.js
@@ -1,0 +1,123 @@
+// trec_eval-compatible retrieval metrics, as used by BEIR (via pytrec_eval).
+//
+// Semantics follow the official trec_eval C source:
+//   - nDCG@k:   linear gain, DCG = Σ rel_i / log2(i + 1) over 1-based ranks i ≤ k
+//               (NOT the 2^rel - 1 variant). IDCG is the same sum over the ideal
+//               ordering of all judged docs, truncated at k. Queries with IDCG = 0
+//               are dropped from the average.
+//   - MAP@k:    map_cut semantics — AP@k = Σ P@r over ranks r ≤ k where rel_r > 0,
+//               divided by the TOTAL number of relevant docs in the qrels
+//               (not capped at k).
+//   - Recall@k: |top-k ∩ relevant| / |relevant|
+//   - P@k:      |top-k ∩ relevant| / k   (denominator is k even for shorter runs)
+//   - MRR@k:    BEIR's custom metric — 1/rank of the first hit with rel ≥ 1 within
+//               the top k, else 0.
+//
+// `run` is a ranked array of corpus doc ids (best first); `queryQrels` is a
+// Map<docId, score>. Unjudged docs count as score 0.
+
+export function ndcgAtK(run, queryQrels, k) {
+  let dcg = 0
+  const top = run.slice(0, k)
+  for (let i = 0; i < top.length; i++) {
+    const rel = queryQrels.get(top[i]) ?? 0
+    dcg += rel / Math.log2(i + 2)
+  }
+
+  const ideal = [...queryQrels.values()].sort((a, b) => b - a).slice(0, k)
+  let idcg = 0
+  for (let i = 0; i < ideal.length; i++) {
+    idcg += ideal[i] / Math.log2(i + 2)
+  }
+
+  return idcg === 0 ? null : dcg / idcg
+}
+
+export function averagePrecisionAtK(run, queryQrels, k) {
+  const relevant = [...queryQrels.values()].filter((score) => score > 0).length
+  if (relevant === 0) {
+    return null
+  }
+
+  let hits = 0
+  let precisionSum = 0
+  const top = run.slice(0, k)
+  for (let i = 0; i < top.length; i++) {
+    if ((queryQrels.get(top[i]) ?? 0) > 0) {
+      hits++
+      precisionSum += hits / (i + 1)
+    }
+  }
+
+  return precisionSum / relevant
+}
+
+export function recallAtK(run, queryQrels, k) {
+  const relevant = [...queryQrels.values()].filter((score) => score > 0).length
+  if (relevant === 0) {
+    return null
+  }
+
+  let hits = 0
+  for (const docId of run.slice(0, k)) {
+    if ((queryQrels.get(docId) ?? 0) > 0) {
+      hits++
+    }
+  }
+
+  return hits / relevant
+}
+
+export function precisionAtK(run, queryQrels, k) {
+  let hits = 0
+  for (const docId of run.slice(0, k)) {
+    if ((queryQrels.get(docId) ?? 0) > 0) {
+      hits++
+    }
+  }
+
+  return hits / k
+}
+
+export function reciprocalRankAtK(run, queryQrels, k) {
+  const top = run.slice(0, k)
+  for (let i = 0; i < top.length; i++) {
+    if ((queryQrels.get(top[i]) ?? 0) > 0) {
+      return 1 / (i + 1)
+    }
+  }
+
+  return 0
+}
+
+function mean(values) {
+  const present = values.filter((value) => value !== null)
+  return present.length > 0 ? present.reduce((sum, value) => sum + value, 0) / present.length : 0
+}
+
+// perQueryRuns: Map<queryId, string[]>; qrels: Map<queryId, Map<docId, score>>.
+// Queries in qrels but missing from the run score 0 (empty ranking).
+export function evaluateRun(perQueryRuns, qrels) {
+  const ndcg = []
+  const map = []
+  const recall = []
+  const precision = []
+  const mrr = []
+
+  for (const [queryId, queryQrels] of qrels) {
+    const run = perQueryRuns.get(queryId) ?? []
+    ndcg.push(ndcgAtK(run, queryQrels, 10))
+    map.push(averagePrecisionAtK(run, queryQrels, 100))
+    recall.push(recallAtK(run, queryQrels, 100))
+    precision.push(precisionAtK(run, queryQrels, 10))
+    mrr.push(reciprocalRankAtK(run, queryQrels, 10))
+  }
+
+  return {
+    ndcg10: mean(ndcg),
+    map100: mean(map),
+    recall100: mean(recall),
+    precision10: mean(precision),
+    mrr10: mean(mrr)
+  }
+}

--- a/benchmarks/src/search-quality/metrics.test.js
+++ b/benchmarks/src/search-quality/metrics.test.js
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  averagePrecisionAtK,
+  evaluateRun,
+  ndcgAtK,
+  precisionAtK,
+  recallAtK,
+  reciprocalRankAtK
+} from './metrics.js'
+
+const TOLERANCE = 1e-9
+
+function closeTo(actual, expected) {
+  assert.ok(Math.abs(actual - expected) < TOLERANCE, `expected ${actual} ≈ ${expected}`)
+}
+
+describe('ndcgAtK (trec_eval linear gain)', () => {
+  it('uses linear gain and log2(i + 1) discount', () => {
+    const qrels = new Map([['a', 2], ['b', 1], ['c', 3]])
+    const run = ['c', 'x', 'a']
+    // DCG  = 3/log2(2) + 0/log2(3) + 2/log2(4) = 3 + 0 + 1 = 4
+    // IDCG = 3/log2(2) + 2/log2(3) + 1/log2(4) = 3 + 1.2618595 + 0.5
+    closeTo(ndcgAtK(run, qrels, 10), 4 / (3 + 2 / Math.log2(3) + 0.5))
+  })
+
+  it('truncates both DCG and IDCG at k', () => {
+    const qrels = new Map([['a', 2], ['b', 1], ['c', 3]])
+    // k=1: DCG = rel(c)/log2(2) = 3, IDCG = 3 -> 1.0
+    closeTo(ndcgAtK(['c'], qrels, 1), 1)
+    closeTo(ndcgAtK(['a'], qrels, 1), 2 / 3)
+  })
+
+  it('returns null when IDCG is 0 (no judged relevant docs)', () => {
+    assert.equal(ndcgAtK(['a'], new Map([['a', 0]]), 10), null)
+  })
+
+  it('treats unjudged docs as 0', () => {
+    closeTo(ndcgAtK(['x', 'a'], new Map([['a', 1]]), 10), 1 / Math.log2(3))
+  })
+})
+
+describe('averagePrecisionAtK (trec_eval map_cut)', () => {
+  it('divides by total relevant docs, not by those retrieved within k', () => {
+    const qrels = new Map([['a', 1], ['b', 1], ['c', 1], ['d', 1]])
+    // run@2 = [a, x]: only P@1 = 1 counts -> AP = 1/4
+    closeTo(averagePrecisionAtK(['a', 'x'], qrels, 2), 0.25)
+  })
+
+  it('accumulates precision at every relevant rank', () => {
+    const qrels = new Map([['a', 1], ['b', 1]])
+    // run = [a, x, b]: P@1 = 1, P@3 = 2/3 -> AP = (1 + 2/3) / 2 = 5/6
+    closeTo(averagePrecisionAtK(['a', 'x', 'b'], qrels, 10), 5 / 6)
+  })
+
+  it('returns null when the query has no relevant docs', () => {
+    assert.equal(averagePrecisionAtK(['a'], new Map([['a', 0]]), 10), null)
+  })
+})
+
+describe('recallAtK / precisionAtK', () => {
+  const qrels = new Map([['a', 1], ['b', 2]])
+
+  it('computes recall over all relevant docs', () => {
+    closeTo(recallAtK(['a', 'x'], qrels, 2), 0.5)
+    closeTo(recallAtK(['a', 'x', 'b'], qrels, 3), 1)
+  })
+
+  it('uses k as the precision denominator even for short runs', () => {
+    closeTo(precisionAtK(['a'], qrels, 10), 0.1)
+  })
+
+  it('counts any positive score as relevant', () => {
+    closeTo(precisionAtK(['b'], qrels, 10), 0.1)
+  })
+})
+
+describe('reciprocalRankAtK (BEIR MRR)', () => {
+  it('is 1/rank of the first relevant hit', () => {
+    const qrels = new Map([['a', 1]])
+    closeTo(reciprocalRankAtK(['x', 'x', 'a'], qrels, 10), 1 / 3)
+  })
+
+  it('is 0 on a miss within k', () => {
+    const qrels = new Map([['a', 1]])
+    assert.equal(reciprocalRankAtK(['x', 'x'], qrels, 2), 0)
+    assert.equal(reciprocalRankAtK(['x', 'x', 'a'], qrels, 2), 0)
+  })
+})
+
+describe('evaluateRun', () => {
+  it('averages over judged queries and drops null-metric queries', () => {
+    const qrels = new Map([
+      ['q1', new Map([['a', 1]])],
+      ['q2', new Map([['b', 0]])] // no relevant docs -> dropped from ndcg/map/recall
+    ])
+    const runs = new Map([
+      ['q1', ['a']],
+      ['q2', ['a']]
+    ])
+    const metrics = evaluateRun(runs, qrels)
+    closeTo(metrics.ndcg10, 1)
+    closeTo(metrics.map100, 1)
+    closeTo(metrics.recall100, 1)
+    // precision/mrr have no null case: q2's hit 'a' is unjudged -> contributes 0
+    closeTo(metrics.precision10, 0.05)
+    closeTo(metrics.mrr10, 0.5)
+  })
+
+  it('scores queries missing from the run as 0', () => {
+    const qrels = new Map([
+      ['q1', new Map([['a', 1]])],
+      ['q2', new Map([['b', 1]])]
+    ])
+    const metrics = evaluateRun(new Map([['q1', ['a']]]), qrels)
+    closeTo(metrics.ndcg10, 0.5)
+    closeTo(metrics.recall100, 0.5)
+    closeTo(metrics.mrr10, 0.5)
+  })
+})

--- a/packages/plugin-pt15/src/index.ts
+++ b/packages/plugin-pt15/src/index.ts
@@ -155,7 +155,10 @@ function createComponents(schema: AnySchema): Partial<ObjectComponents<any, any,
         boost: Partial<Record<OnlyStrings<FlattenSchemaProperty<T>[]>, number>>,
         relevance: Required<BM25Params>,
         docsCount: number,
-        whereFiltersIDs: Set<InternalDocumentID> | undefined
+        whereFiltersIDs: Set<InternalDocumentID> | undefined,
+        threshold?: number,
+        // PT15 indexes every token prefix at insert time, so its matching is inherently prefix-based and the `prefix` flag has no effect here.
+        prefix?: boolean
       ): TokenScore[] {
         if (tolerance !== 0) {
           throw new Error('Tolerance not implemented yet')

--- a/packages/plugin-qps/src/index.ts
+++ b/packages/plugin-qps/src/index.ts
@@ -39,7 +39,10 @@ function search<T extends AnyZBSearch>(
   boost: Partial<Record<OnlyStrings<FlattenSchemaProperty<T>[]>, number>>,
   relevance: Required<BM25Params>,
   docsCount: number,
-  whereFiltersIDs: Set<InternalDocumentID> | undefined
+  whereFiltersIDs: Set<InternalDocumentID> | undefined,
+  threshold?: number,
+  // QPS expands tokens and scores exact matches above prefixed ones itself, so the `prefix` flag has no effect here.
+  prefix?: boolean
 ): TokenScore[] {
   const all: Map<InternalDocumentID, [number, number]> = new Map()
 

--- a/packages/runtime-cloudflare/deploy/lib.mjs
+++ b/packages/runtime-cloudflare/deploy/lib.mjs
@@ -387,7 +387,7 @@ export function getR2Credentials(configOrEnv) {
 }
 
 export function step(message) {
-  console.log(`\n→ ${message}`)
+  console.log(`\n-> ${message}`)
 }
 
 export async function run(command, args, { allowFailure = false, dryRun = false, input, cwd } = {}) {

--- a/packages/stemmers/lib/cs.js
+++ b/packages/stemmers/lib/cs.js
@@ -84,9 +84,9 @@ function removePossessives(word) {
 
 /**
  * Normalizes the stem ending so inflectional variants conflate:
- * palatalized consonants are rewritten ("čt" → "ck", "št" → "sk",
- * "c"/"č" → "k", "z"/"ž" → "h"), a fleeting penultimate "e" is dropped
- * ("desek" → "desk") and a penultimate "ů" becomes "o" ("dům" → "dom").
+ * palatalized consonants are rewritten ("čt" -> "ck", "št" -> "sk",
+ * "c"/"č" -> "k", "z"/"ž" -> "h"), a fleeting penultimate "e" is dropped
+ * ("desek" -> "desk") and a penultimate "ů" becomes "o" ("dům" -> "dom").
  */
 function normalize(word) {
   if (word.endsWith('čt')) {

--- a/packages/stemmers/lib/sl.js
+++ b/packages/stemmers/lib/sl.js
@@ -84,8 +84,8 @@ const ENDINGS = [
   ['eš', 3],
   ['iš', 3],
   // nouns: instrumental singular f. (nočjo, perutjo); with the vowel trim
-  // below this also covers the 3rd person plural (delajo → dela → del,
-  // nosijo → nosi → nos)
+  // below this also covers the 3rd person plural (delajo -> dela -> del,
+  // nosijo -> nosi -> nos)
   ['jo', 3],
   // nouns: dual/plural dative and instrumental in -ma/-mi (hišama, stvarmi)
   ['ma', 4],
@@ -119,11 +119,11 @@ export function stemmer(word) {
     }
   }
 
-  // Step 2: trim residual theme/case vowels (mesta → mest, hiši → hiš),
-  // plus a final 'j' glide when it follows a consonant (vprašanje →
-  // vprašanj → vprašan, bratje → brat) or an 'i' - where -ij- is always an
+  // Step 2: trim residual theme/case vowels (mesta -> mest, hiši -> hiš),
+  // plus a final 'j' glide when it follows a consonant (vprašanje ->
+  // vprašanj -> vprašan, bratje -> brat) or an 'i' - where -ij- is always an
   // inflectional/thematic tail, so the whole -ija class collapses (operacija,
-  // operacije, operacijo, operacij → operac; ladja/ladij → lad). After
+  // operacije, operacijo, operacij -> operac; ladja/ladij -> lad). After
   // a/e/o/u the 'j' is part of the stem (muzej, kraj, razvoj) and is kept.
   // The stem is never shortened below 3 characters.
   let end = stem.length

--- a/packages/zbsearch/README.md
+++ b/packages/zbsearch/README.md
@@ -227,7 +227,7 @@ Read the complete documentation at [https://zbsearch.dev](https://zbsearch.dev).
 - [Plugin QPS](https://zbsearch.dev/docs/zbsearch/plugins/plugin-qps)
 - [Plugin PT15](https://zbsearch.dev/docs/zbsearch/plugins/plugin-pt15)
 
-Write your own plugin: [https://zbsearch.dev](https://zbsearch.dev)
+Write your own plugin: [https://www.zbsearch.dev/docs/zbsearch/plugins/writing-your-own-plugins](https://www.zbsearch.dev/docs/zbsearch/plugins/writing-your-own-plugins)
 
 # License
 

--- a/packages/zbsearch/src/components/index.ts
+++ b/packages/zbsearch/src/components/index.ts
@@ -129,14 +129,13 @@ export function insertRadixTokens(
   insertDocumentScoreParameters(index, prop, id, tokens, docsCount, internalId)
   const frequencies = index.frequencies[prop][internalId]!
   const tokenLength = tokens.length
-  const invLength = tokenLength > 0 ? 1 / tokenLength : 0
 
   for (let i = 0; i < tokenLength; i++) {
     const token = tokens[i]!
     if (Object.hasOwn(frequencies, token)) {
-      frequencies[token] += invLength
+      frequencies[token] += 1
     } else {
-      frequencies[token] = invLength
+      frequencies[token] = 1
       node.insert(token, internalId)
     }
   }
@@ -509,6 +508,28 @@ function filterIdsToCandidates(
   return filtered
 }
 
+// Prefix-expanded words (the query token is a strict prefix of the indexed word) score at a demoted weight so that documents matching the full query token always outrank partial, prefix-only matches.
+const PREFIX_EXPANSION_SCORE_DEMOTION = 0.5
+
+function bm25Idf(documentFrequency: number, docsCount: number): number {
+  return Math.log(1 + (docsCount - documentFrequency + 0.5) / (documentFrequency + 0.5))
+}
+
+// Demotion factor for a prefix-expanded word. Beyond the flat demotion, the word's effective IDF is capped at the exact token's IDF (Lucene blends term statistics across expansions the same way): a rare expansion must not outscore the exact token just because it appears in fewer documents.
+function prefixExpansionDemotion(tokenDf: number | undefined, wordDf: number, docsCount: number): number {
+  if (tokenDf === undefined) {
+    return PREFIX_EXPANSION_SCORE_DEMOTION
+  }
+
+  const wordIdf = bm25Idf(wordDf, docsCount)
+
+  if (!wordIdf) {
+    return PREFIX_EXPANSION_SCORE_DEMOTION
+  }
+
+  return PREFIX_EXPANSION_SCORE_DEMOTION * Math.min(1, bm25Idf(tokenDf, docsCount) / wordIdf)
+}
+
 function searchThresholdZero(
   index: Index,
   tokens: string[],
@@ -613,7 +634,7 @@ function searchThresholdZero(
             docsCount,
             relevance,
             resultsMap,
-            boostPerProperty,
+            boostPerProperty * (word === token ? 1 : prefixExpansionDemotion(searchResult[token]?.length, searchResult[word]!.length, docsCount)),
             whereFiltersIDs
           )
         }
@@ -638,7 +659,8 @@ export function search(
   relevance: Required<BM25Params>,
   docsCount: number,
   whereFiltersIDs: Set<InternalDocumentID> | undefined,
-  threshold = 0
+  threshold = 0,
+  prefix = true
 ): TokenScore[] {
   const tokens = tokenizer.tokenize(term, language)
   const keywordsCount = tokens.length || 1
@@ -647,12 +669,14 @@ export function search(
     tokens.push('')
   }
 
+  const radixExact = term ? exact || (!prefix && !tolerance) : false
+
   if (!threshold && tokens.length > 1) {
     return searchThresholdZero(
       index,
       tokens,
       propertiesToSearch,
-      exact,
+      radixExact,
       tolerance,
       boost,
       relevance,
@@ -686,7 +710,7 @@ export function search(
     const tokenLength = tokens.length
     for (let i = 0; i < tokenLength; i++) {
       const token = tokens[i]
-      const searchResult = tree.node.find({ term: token, exact, tolerance })
+      const searchResult = tree.node.find({ term: token, exact: radixExact, tolerance })
 
       // See if this token was found (for threshold=0 filtering)
       const termsFound = Object.keys(searchResult)
@@ -707,7 +731,7 @@ export function search(
           docsCount,
           relevance,
           resultsMap,
-          boostPerProperty,
+          boostPerProperty * (word === token ? 1 : prefixExpansionDemotion(searchResult[token]?.length, ids!.length, docsCount)),
           whereFiltersIDs,
           keywordMatchesMap
         )

--- a/packages/zbsearch/src/methods/search-fulltext.ts
+++ b/packages/zbsearch/src/methods/search-fulltext.ts
@@ -24,7 +24,7 @@ export function innerFullTextSearch<T extends AnyZBSearch>(
   zbsearch: T,
   params: Pick<
     SearchParamsFullText<T>,
-    'term' | 'properties' | 'where' | 'exact' | 'tolerance' | 'boost' | 'relevance' | 'threshold'
+    'term' | 'properties' | 'where' | 'exact' | 'prefix' | 'tolerance' | 'boost' | 'relevance' | 'threshold'
   >,
   language: Language | undefined,
   precomputedWhereFiltersIDs?: Set<number>
@@ -84,7 +84,8 @@ export function innerFullTextSearch<T extends AnyZBSearch>(
       applyDefault(params.relevance),
       docsCount,
       whereFiltersIDs,
-      threshold
+      threshold,
+      params.prefix
     )
 
     // When exact is true and we have a term, filter results to only include documents

--- a/packages/zbsearch/src/types.ts
+++ b/packages/zbsearch/src/types.ts
@@ -348,6 +348,12 @@ export interface SearchParamsFullText<T extends AnyZBSearch, ResultDocument = Ty
   exact?: boolean
 
   /**
+   * Whether to enable prefix matching (search-as-you-type), expanding each query token to every indexed word that starts with it — like Lucene's PrefixQuery.
+   * Enabled by default; prefix-expanded words score at a demoted weight so documents matching the full token rank higher. Set to false for Lucene-style exact token matching (best relevance on full-text queries). Ignored when `exact` or `tolerance` is set.
+   */
+  prefix?: boolean
+
+  /**
    * The maximum [levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)
    * between the term and the searchable property.
    */
@@ -1017,7 +1023,8 @@ export interface IIndex<I extends AnyIndexStore> {
     relevance: Required<BM25Params>,
     docsCount: number,
     whereFiltersIDs: Set<InternalDocumentID> | undefined,
-    threshold?: number
+    threshold?: number,
+    prefix?: boolean
   ): TokenScore[]
 
   searchByWhereClause<T extends AnyZBSearch>(

--- a/packages/zbsearch/tests/array.test.ts
+++ b/packages/zbsearch/tests/array.test.ts
@@ -23,7 +23,8 @@ t.test('create should support array of string', async (t) => {
   await checkSearchTerm(t, db, 'Harry', [harryId])
   await checkSearchTerm(t, db, 'James', [harryId, jamesId])
   await checkSearchTerm(t, db, 'Potter', [harryId, jamesId, lilyId])
-  await checkSearchTerm(t, db, 'P', [albusId, harryId, jamesId, lilyId])
+  // 'P' is a fragment of indexed words ('Percival', 'Potter'), so opt into prefix expansion.
+  await checkSearchTerm(t, db, 'P', [albusId, harryId, jamesId, lilyId], { prefix: true })
   await checkSearchTerm(t, db, 'foo', [])
 
   await checkSearchWhere(t, db, 'name', 'Albus', [albusId])
@@ -230,9 +231,10 @@ t.test('update supports array as well', async (t) => {
   t.ok(newDocId)
 })
 
-async function checkSearchTerm(t, db, term, expectedIds) {
+async function checkSearchTerm(t, db, term, expectedIds, extraParams = {}) {
   const result = await search(db, {
-    term
+    term,
+    ...extraParams
   })
   t.equal(result.hits.length, expectedIds.length)
   t.equal(result.count, expectedIds.length)

--- a/packages/zbsearch/tests/enum.test.ts
+++ b/packages/zbsearch/tests/enum.test.ts
@@ -249,13 +249,16 @@ t.test('enum', async (t) => {
       { title: 'The Lord of the Rings: The Return of the King', year: 2003, categoryId: 4 }
     ])
 
+    // 'r' is a fragment of indexed words, so opt into prefix expansion.
     const result1 = await search(filmDb, {
-      term: 'r'
+      term: 'r',
+      prefix: true
     })
     t.equal(result1.hits.length, 2)
 
     const result2 = await search(filmDb, {
       term: 'r',
+      prefix: true,
       where: {
         categoryId: { eq: 1 }
       }
@@ -268,6 +271,7 @@ t.test('enum', async (t) => {
 
     const result3 = await search(filmDb, {
       term: 'r',
+      prefix: true,
       where: {
         year: { gt: 2000 },
         categoryId: { eq: 1 }
@@ -281,6 +285,7 @@ t.test('enum', async (t) => {
 
     const result4 = await search(filmDb, {
       term: 'r',
+      prefix: true,
       where: {
         year: { lte: 2000 },
         categoryId: { eq: 1 }
@@ -525,13 +530,16 @@ t.test('enum[]', async (t) => {
       { title: 'The Lord of the Rings: The Return of the King', year: 2003, tags: ['fantasy', 'adventure'] }
     ])
 
+    // 'l' is a fragment of indexed words, so opt into prefix expansion.
     const result1 = await search(filmDb, {
-      term: 'l'
+      term: 'l',
+      prefix: true
     })
     t.equal(result1.hits.length, 2)
 
     const result2 = await search(filmDb, {
       term: 'l',
+      prefix: true,
       where: {
         tags: { containsAll: ['war'] }
       }
@@ -544,6 +552,7 @@ t.test('enum[]', async (t) => {
 
     const result3 = await search(filmDb, {
       term: 'l',
+      prefix: true,
       where: {
         year: { gt: 2000 },
         tags: { containsAll: ['war'] }
@@ -557,6 +566,7 @@ t.test('enum[]', async (t) => {
 
     const result4 = await search(filmDb, {
       term: 'l',
+      prefix: true,
       where: {
         year: { lte: 2000 },
         tags: { containsAll: ['war'] }

--- a/packages/zbsearch/tests/insert.test.ts
+++ b/packages/zbsearch/tests/insert.test.ts
@@ -370,7 +370,7 @@ t.test('insert short prefixes, as in #327 and #328', async (t) => {
 
     const prefixResults = await search(db, {
       term: 'RD',
-      exact: false
+      prefix: true
     })
 
     t.same(exactResults.count, 1)
@@ -378,10 +378,10 @@ t.test('insert short prefixes, as in #327 and #328', async (t) => {
     t.same(exactResults.hits[0].document.abbrv, 'RD')
 
     t.same(prefixResults.count, 2)
-    t.same(prefixResults.hits[0].id, '1')
-    t.same(prefixResults.hits[0].document.abbrv, 'RDGE')
-    t.same(prefixResults.hits[1].id, '2')
-    t.same(prefixResults.hits[1].document.abbrv, 'RD')
+    t.same(prefixResults.hits[0].id, '2')
+    t.same(prefixResults.hits[0].document.abbrv, 'RD')
+    t.same(prefixResults.hits[1].id, '1')
+    t.same(prefixResults.hits[1].document.abbrv, 'RDGE')
   })
 
   await t.test('example 2', async (t) => {
@@ -548,6 +548,7 @@ t.test('insertMultiple method', async (t) => {
 
     const results250 = await search(db, {
       term: 'name',
+      prefix: true,
       where: {
         number: {
           eq: 250

--- a/packages/zbsearch/tests/issue-866.test.ts
+++ b/packages/zbsearch/tests/issue-866.test.ts
@@ -64,11 +64,10 @@ t.test('issue-866: exact search should only match exact terms', async (t) => {
     await insert(db, { name: 'apple' })
     await insert(db, { name: 'application' })
     await insert(db, { name: 'app' })
-
-    // Without exact, "app" should match all three
+    
     const noExact = await search(db, {
       term: 'app',
-      exact: false
+      prefix: true
     })
 
     // With exact: true, "app" should only match the document with "app"
@@ -77,7 +76,7 @@ t.test('issue-866: exact search should only match exact terms', async (t) => {
       exact: true
     })
 
-    t.equal(noExact.count, 3, 'Without exact, should match all prefix matches')
+    t.equal(noExact.count, 3, 'With prefix: true, should match all prefix matches')
     t.equal(withExact.count, 1, 'With exact: true, should only match exact term')
     t.equal(withExact.hits[0].document.name, 'app', 'Should match only "app"')
   })

--- a/packages/zbsearch/tests/levenshtein.test.ts
+++ b/packages/zbsearch/tests/levenshtein.test.ts
@@ -248,9 +248,10 @@ t.test('Issue #744', async (t) => {
     tolerance: 2
   })
   t.equal(s4.count, 4)
+  // Exact matches (docs 1-2 contain 'moelleux') outrank fuzzy tolerance-2 matches (docs 3-4): full-token matches always score above expansions.
   t.strictSame(
     s4.hits.map((h) => h.id),
-    ['3', '4', '1', '2']
+    ['1', '2', '3', '4']
   )
 })
 

--- a/packages/zbsearch/tests/main.test.ts
+++ b/packages/zbsearch/tests/main.test.ts
@@ -268,13 +268,17 @@ t.test('should correctly search words in Bulgarian', async (t) => {
     description: 'Гръдните мускули на пингвините са много по-мощни от тези на летящите им родственици'
   })
 
+  // 'пингвин' is a fragment of the indexed 'пингвините', so opt into prefix expansion.
   const firstSearchResult = await search(db, {
-    term: 'пингвин'
+    term: 'пингвин',
+    prefix: true
   })
   t.equal(firstSearchResult.count, 2)
 
+  // 'жълта' is a fragment of the indexed 'жълтата', so opt into prefix expansion.
   const secondSearchResult = await search(db, {
-    term: 'жълта'
+    term: 'жълта',
+    prefix: true
   })
   t.equal(secondSearchResult.count, 1)
 })

--- a/packages/zbsearch/tests/plugin-embeddings-serialization.test.ts
+++ b/packages/zbsearch/tests/plugin-embeddings-serialization.test.ts
@@ -29,6 +29,7 @@ t.test('Plugin embeddings serialization', async (t) => {
 
     const searchResults = await search(db, {
       term: '',
+      prefix: true, // empty-term match-all now requires opting into prefix expansion
       properties: ['title'],
       includeVectors: true
     })
@@ -55,6 +56,7 @@ t.test('Plugin embeddings serialization', async (t) => {
 
     const restoredResults = await search(newDb, {
       term: '',
+      prefix: true, // empty-term match-all now requires opting into prefix expansion
       properties: ['title'],
       includeVectors: true
     })
@@ -106,6 +108,7 @@ t.test('Plugin embeddings serialization', async (t) => {
 
     const allDocs = await search(db, {
       term: '',
+      prefix: true, // empty-term match-all now requires opting into prefix expansion
       properties: ['title'],
       includeVectors: true
     })
@@ -137,6 +140,7 @@ t.test('Plugin embeddings serialization', async (t) => {
 
     const restoredDocs = await search(newDb, {
       term: '',
+      prefix: true, // empty-term match-all now requires opting into prefix expansion
       properties: ['title'],
       includeVectors: true
     })

--- a/packages/zbsearch/tests/remove.test.ts
+++ b/packages/zbsearch/tests/remove.test.ts
@@ -112,8 +112,10 @@ t.test('remove method', (t) => {
 
     await remove(zbsearch, halo)
 
+    // 'Hal' is a fragment of the indexed 'Halloween', so opt into prefix expansion.
     const searchResult = await search(zbsearch, {
-      term: 'Hal'
+      term: 'Hal',
+      prefix: true
     })
 
     t.equal(searchResult.count, 2)

--- a/packages/zbsearch/tests/search.test.ts
+++ b/packages/zbsearch/tests/search.test.ts
@@ -19,7 +19,8 @@ t.test('search method', async (t) => {
     t.equal((await search(db, { term: 'СЪЕШЬ' })).count, 1, 'is case-insensitive across scripts')
     t.equal((await search(db, { term: 'cafe' })).count, 1, 'folds diacritics')
     t.equal((await search(db, { term: 'テキスト' })).count, 1, 'finds CJK text')
-    t.equal((await search(db, { term: '日本' })).count, 1, 'prefix-matches CJK text')
+    // '日本' is a prefix of an indexed CJK token, so opt into prefix expansion.
+    t.equal((await search(db, { term: '日本', prefix: true })).count, 1, 'prefix-matches CJK text')
     t.equal((await search(db, { term: 'nonexistent' })).count, 0, 'returns nothing for absent terms')
   })
 
@@ -391,7 +392,8 @@ t.test('search method', async (t) => {
         const { limit, offset, expectedIds } = c
         const name = `limit: ${limit}, offset: ${offset}`
         t.test(name, async (t) => {
-          const result = await search(db, { term: 'f', limit, offset })
+          // 'f' is a fragment of the indexed words, so opt into prefix expansion.
+          const result = await search(db, { term: 'f', limit, offset, prefix: true })
           const actualIds = result.hits.map((d) => d.id)
 
           t.equal(result.count, 4)
@@ -775,7 +777,9 @@ t.test('fix-544', async (t) => {
   await insert(db, { name: 'Christopher' })
   let result
 
-  result = await search(db, { term: 'Chris', tolerance: 0 })
+  // 'Chris' is a prefix of the indexed (stemmed) 'Christopher', so opt into
+  // prefix expansion: exact matching is now the default and would not match.
+  result = await search(db, { term: 'Chris', tolerance: 0, prefix: true })
   t.equal(result.count, 1)
 
   result = await search(db, { term: 'Chris', tolerance: 1 })

--- a/packages/zbsearch/tests/snapshots/events.json
+++ b/packages/zbsearch/tests/snapshots/events.json
@@ -4,7 +4,7 @@
     "hits": [
       {
         "id": "",
-        "score": 4.744420806219526,
+        "score": 5.219060873137768,
         "document": {
           "date": "-53",
           "description": "Parthian war:",
@@ -17,7 +17,7 @@
       },
       {
         "id": "",
-        "score": 4.087292400578752,
+        "score": 4.982684534970456,
         "document": {
           "date": "1728/10/20",
           "description": "The Meerkat–Mongoose war.",
@@ -30,7 +30,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "-156",
           "description": "The first Dalmatian war begins.",
@@ -43,7 +43,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "-119",
           "description": "The second Dalmatian war begins.",
@@ -56,7 +56,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "-78",
           "description": "The Third Dalmatian war begins.",
@@ -69,7 +69,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "599",
           "description": "The Chinese win the war at Ordos.",
@@ -82,7 +82,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1027/08/16",
           "description": "Civil war begins in Japan.",
@@ -95,7 +95,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1695/12/31",
           "description": "Russia declares war on Turkey.",
@@ -108,7 +108,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1792/04/20",
           "description": " France declares war against Austria.",
@@ -121,7 +121,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1792/06/04",
           "description": "Prussia declares war against France.",
@@ -139,7 +139,7 @@
     "hits": [
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1793/03/07",
           "description": " France declares war on Spain.",
@@ -152,7 +152,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1804/12/12",
           "description": " Spain declares war on Britain",
@@ -165,7 +165,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1805/12/26",
           "description": "Sweden declares war on France.",
@@ -178,7 +178,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1823/12/02",
           "description": "Beginning of the first Anglo-Ashanti war.",
@@ -191,7 +191,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1841/04/06",
           "description": "May ampampndash Start of the Sino-Sikh war.",
@@ -204,7 +204,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1854/03/28",
           "description": " France declares war on Russia.",
@@ -217,7 +217,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1878/02/02",
           "description": " Greece declares war on Turkey.",
@@ -230,7 +230,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1914/08/04",
           "description": "Montenegro declares war on Austria-Hungary.",
@@ -243,7 +243,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1914/08/06",
           "description": " Austria-Hungary declares war on Russia.",
@@ -256,7 +256,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1914/08/23",
           "description": " Japan declares war on Germany.",
@@ -274,7 +274,7 @@
     "hits": [
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1933/05/08",
           "description": "Paraguay declares war on Bolivia.",
@@ -287,7 +287,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1941/12/07",
           "description": "Canada declares war on Japan.",
@@ -300,7 +300,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1943/01/16",
           "description": " Iraq declares war on the Axis",
@@ -313,7 +313,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1945/07/14",
           "description": " Italy declares war on Japan.",
@@ -326,7 +326,7 @@
       },
       {
         "id": "",
-        "score": 3.5440127681974047,
+        "score": 4.766791898138612,
         "document": {
           "date": "1962/09/26",
           "description": " Civil war erupts in Yemen.",
@@ -339,7 +339,7 @@
       },
       {
         "id": "",
-        "score": 3.1042893935925617,
+        "score": 4.568830948804273,
         "document": {
           "date": "17/05/26",
           "description": "Beginning of a civil war in Germania.",
@@ -352,7 +352,7 @@
       },
       {
         "id": "",
-        "score": 3.1042893935925617,
+        "score": 4.568830948804273,
         "document": {
           "date": "350/12/25",
           "description": "The Wei-Jie war breaks out in North China.",
@@ -365,7 +365,7 @@
       },
       {
         "id": "",
-        "score": 3.1042893935925617,
+        "score": 4.568830948804273,
         "document": {
           "date": "618",
           "description": "A civil war begins in Medina.",
@@ -378,7 +378,7 @@
       },
       {
         "id": "",
-        "score": 3.1042893935925617,
+        "score": 4.568830948804273,
         "document": {
           "date": "1240/07/15",
           "description": "The civil war era in Norway ends.",
@@ -391,7 +391,7 @@
       },
       {
         "id": "",
-        "score": 3.1042893935925617,
+        "score": 4.568830948804273,
         "document": {
           "date": "1635/04/13",
           "description": "May ampampndash France declares war on Spain.",

--- a/packages/zbsearch/tests/threshold.test.ts
+++ b/packages/zbsearch/tests/threshold.test.ts
@@ -154,6 +154,7 @@ t.test('should return all the exact matches + X% of the partial matches', async 
 })
 
 // Related issue: https://github.com/oramasearch/orama/issues/911
+// Note: these cases exercise prefix (search-as-you-type) matching, which is opt-in via `prefix: true` - default search matches whole tokens exactly.
 t.test('should return results for words with same root if threshold is 0', async (t) => {
   const db = create({
     schema: {
@@ -194,7 +195,7 @@ t.test('should return results for words with same root if threshold is 0', async
   t.plan(testCases.length)
 
   for (const [term, expectedCount] of testCases) {
-    const result = await search(db, { term, threshold: 0 })
+    const result = await search(db, { term, threshold: 0, prefix: true })
     t.same(
       result.count,
       expectedCount,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Default full-text behavior changes (no prefix expansion unless `prefix: true`) and BM25 term-frequency/scoring updates can alter production rankings and break clients that relied on implicit prefix matching; the core search path is directly modified.
> 
> **Overview**
> **BM25 and full-text defaults** change how ranking works: per-token field frequencies are now integer counts (not length-normalized fractions), prefix-expanded terms get Lucene-style score demotion (including IDF capping), and omitting `prefix` on `search()` no longer expands prefixes—`prefix: true` is required for search-as-you-type. The new `prefix` search param is wired through types, full-text search, and QPS/PT15 plugin `search` signatures (documented as no-ops there).
> 
> **BEIR search-quality harness** adds `benchmarks/search-quality.js` with dataset download/cache, trec_eval-compatible metrics + unit tests, multi-engine adapters (ZBSearch BM25/QPS/PT15, Orama with stemmers/stopwords, Lunr, FlexSearch, MiniSearch, Fuse.js), incremental JSON output, and a manual **Search Quality Benchmarks (BEIR)** GitHub Actions workflow. `benchmarks/README.md` documents the suite; `.cache` is gitignored.
> 
> **Tests and snapshots** are updated for exact-token defaults (`prefix: true` where partial matches are intended), ranking order (e.g. levenshtein), and BM25 score changes in `events.json`. Minor doc/comment arrow formatting and a README plugin link fix are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa5a9f0611c8f18ccf99f8d3f02dabc18502050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->