### PR TITLE
Adds IndexedDB + S3 persistence (#32)

### DIFF
--- a/apps/docs/content/docs/zbsearch/plugins/plugin-data-persistence/index.mdx
+++ b/apps/docs/content/docs/zbsearch/plugins/plugin-data-persistence/index.mdx
@@ -104,6 +104,26 @@ import { restoreFromFile } from "@zbsearch/plugin-data-persistence/server";
 const db = await restoreFromFile("binary", filePath);
 ```
 
+## Persisting to a storage backend (IndexedDB, S3, …)
+
+Besides strings, buffers, and the filesystem, you can persist a snapshot
+directly into a pluggable storage backend — such as IndexedDB in the browser or
+S3/R2 on the server — with `persistToStorage` / `restoreFromStorage`:
+
+```javascript copy
+import { persistToStorage, restoreFromStorage } from "@zbsearch/plugin-data-persistence";
+import { IndexedDBStorage } from "@zbsearch/plugin-data-persistence/indexeddb";
+
+const storage = new IndexedDBStorage();
+await persistToStorage(originalInstance, storage, "my-index");
+
+const newInstance = await restoreFromStorage(storage, "my-index");
+```
+
+See [Storage Adapters](/docs/zbsearch/plugins/plugin-data-persistence/storage-adapters)
+for the full guide, the `PersistenceStorage` contract, and how to write your own
+adapter.
+
 # CommonJS Imports
 
 ZBSearch plugins ship **ESM** modules by default. This allows us to move faster when providing new features and bug fixes, as well as using the `"exports"` field in `package.json` to provide a better developer experience.

--- a/apps/docs/content/docs/zbsearch/plugins/plugin-data-persistence/meta.json
+++ b/apps/docs/content/docs/zbsearch/plugins/plugin-data-persistence/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Plugin Data Persistence",
+  "pages": ["index", "storage-adapters"]
+}

--- a/apps/docs/content/docs/zbsearch/plugins/plugin-data-persistence/storage-adapters.mdx
+++ b/apps/docs/content/docs/zbsearch/plugins/plugin-data-persistence/storage-adapters.mdx
@@ -1,0 +1,230 @@
+---
+title: Storage Adapters
+description: Persist a ZBSearch snapshot into IndexedDB, S3, or any custom storage backend, then restore it back into memory.
+---
+
+The `persist` / `restore` and `persistToFile` / `restoreFromFile` APIs serialize
+a database to a string, a buffer, or the local filesystem. **Storage adapters**
+add a third destination: a pluggable backend such as **IndexedDB** in the
+browser, **S3/R2** on the server, or any custom key/value store.
+
+```javascript copy
+import {
+  persistToStorage,
+  restoreFromStorage,
+} from "@zbsearch/plugin-data-persistence";
+import { IndexedDBStorage } from "@zbsearch/plugin-data-persistence/indexeddb";
+
+const storage = new IndexedDBStorage();
+
+// Save the whole index under a key
+await persistToStorage(db, storage, "my-index");
+
+// ...later, e.g. after a page reload
+const restored = await restoreFromStorage(storage, "my-index");
+```
+
+<Callout type="info">
+  This is **snapshot** persistence: the entire index is written as one compact
+  payload, and restoring it loads that payload back into memory. The database is
+  fully in-memory when you query it — searches do **not** run against the
+  storage backend. The goal is durability and portability, not out-of-core
+  search.
+</Callout>
+
+## How it works
+
+`persistToStorage` serializes the database with one of the supported formats and
+writes the resulting bytes to `storage.put(key, bytes)`. `restoreFromStorage`
+reads the bytes back with `storage.get(key)`, deserializes them, and loads them
+into a fresh in-memory instance. The original database is never mutated by
+`persistToStorage`, so you can keep using it while a snapshot is written.
+
+```javascript copy
+// The in-memory db keeps working after persisting
+await persistToStorage(db, storage, "my-index");
+const results = await search(db, { term: "brave" }); // still works
+```
+
+## API
+
+### `persistToStorage(db, storage, key, options?)`
+
+| Argument  | Type                  | Description                                        |
+| --------- | --------------------- | -------------------------------------------------- |
+| `db`      | `ZBSearch`            | The database to snapshot.                          |
+| `storage` | `PersistenceStorage`  | The backend to write to.                           |
+| `key`     | `string`              | The key the snapshot is stored under.              |
+| `options` | `PersistToStorageOptions?` | See below.                                    |
+
+```ts
+interface PersistToStorageOptions {
+  format?: "json" | "dpack" | "binary" | "seqproto"; // defaults to "binary"
+  contentType?: string; // passed through to storage.put (e.g. for S3/HTTP)
+}
+```
+
+### `restoreFromStorage(storage, key, options?)`
+
+Returns a new, fully queryable database. Throws if `key` does not exist in the
+backend.
+
+```ts
+interface RestoreFromStorageOptions {
+  format?: "json" | "dpack" | "binary" | "seqproto"; // defaults to "binary"
+}
+```
+
+<Callout type="warn">
+  The `format` passed to `restoreFromStorage` **must match** the one used to
+  persist. The default for both is `binary`.
+</Callout>
+
+## Choosing a format
+
+All four formats from [`persist`](/docs/zbsearch/plugins/plugin-data-persistence)
+are supported. Unlike `persist("binary")`, which returns a hex string (two
+characters per byte), storage adapters keep `binary` as **raw msgpack bytes**, so
+persisted payloads are roughly half the size.
+
+| Format     | Payload        | Notes                                             |
+| ---------- | -------------- | ------------------------------------------------- |
+| `binary`   | raw msgpack    | **Default.** Smallest, recommended for IndexedDB. |
+| `json`     | UTF-8 JSON     | Human-readable, portable, larger.                 |
+| `dpack`    | dpack bytes    | Node-oriented.                                     |
+| `seqproto` | seqproto bytes | Compact binary, Node-oriented.                    |
+
+For browsers and IndexedDB, prefer `binary` or `json`.
+
+## The `PersistenceStorage` contract
+
+Any object implementing this interface can be used as a backend:
+
+```ts
+interface PersistenceStorage {
+  get(
+    key: string,
+    opts?: { ifNoneMatch?: string }
+  ): Promise<{ body: Uint8Array } | null>;
+  put(
+    key: string,
+    body: Uint8Array,
+    opts?: { contentType?: string }
+  ): Promise<unknown>;
+}
+```
+
+It is intentionally **structurally compatible with `ObjectStorage` from
+`@zbsearch/edge-core`**, so any edge-core storage backend can be passed directly,
+with no adapter in between — see [S3, R2, and MinIO](#s3-cloudflare-r2-and-minio)
+below.
+
+## S3, Cloudflare R2, and MinIO
+
+`S3ObjectStorage` from `@zbsearch/storage-s3` already implements the
+`PersistenceStorage` contract, so it works with `persistToStorage` /
+`restoreFromStorage` **out of the box** — no wrapper needed. This is ideal for
+the "build once, restore on many stateless workers" pattern: persist a prebuilt
+index to S3/R2 and have serverless functions restore it on cold start instead of
+re-indexing.
+
+```javascript copy
+import { S3ObjectStorage } from "@zbsearch/storage-s3";
+import { persistToStorage, restoreFromStorage } from "@zbsearch/plugin-data-persistence";
+
+const s3 = new S3ObjectStorage({
+  bucket: "my-bucket",
+  accessKeyId: "...",
+  secretAccessKey: "...",
+  region: "us-east-1",
+});
+
+await persistToStorage(db, s3, "indexes/my-index.msp");
+const restored = await restoreFromStorage(s3, "indexes/my-index.msp");
+```
+
+For **Cloudflare R2** or **MinIO**, set a custom `endpoint` (path-style
+addressing is enabled automatically):
+
+```javascript copy
+const r2 = new S3ObjectStorage({
+  bucket: "my-bucket",
+  accessKeyId: "...",
+  secretAccessKey: "...",
+  endpoint: "https://<account>.r2.cloudflarestorage.com",
+});
+```
+
+You can also build the storage from environment variables with
+`createS3StorageFromEnv()`, which reads `R2_*` / `S3_*` (and `AWS_REGION`) vars:
+
+```javascript copy
+import { createS3StorageFromEnv } from "@zbsearch/storage-s3";
+
+const storage = createS3StorageFromEnv(); // reads process.env
+await persistToStorage(db, storage, "indexes/my-index.msp");
+```
+
+## IndexedDB adapter
+
+`IndexedDBStorage` gives you durable, in-browser persistence: an index survives
+page reloads without being rebuilt from source documents.
+
+```javascript copy
+import { IndexedDBStorage } from "@zbsearch/plugin-data-persistence/indexeddb";
+
+const storage = new IndexedDBStorage({
+  databaseName: "zbsearch", // default: "zbsearch"
+  storeName: "indexes", // default: "indexes"
+});
+
+await persistToStorage(db, storage, "products");
+const restored = await restoreFromStorage(storage, "products");
+
+await storage.delete("products"); // remove a single snapshot
+await storage.clear(); // remove every snapshot in the store
+await storage.close(); // close the underlying connection
+```
+
+### Injecting a custom factory
+
+The constructor accepts an `indexedDB` factory, which is useful for tests or
+server-side rendering where a global `indexedDB` is not available. Any polyfill
+exposing an `IDBFactory` works (for example
+[`fake-indexeddb`](https://www.npmjs.com/package/fake-indexeddb)):
+
+```javascript copy
+import { IDBFactory } from "fake-indexeddb";
+import { IndexedDBStorage } from "@zbsearch/plugin-data-persistence/indexeddb";
+
+const storage = new IndexedDBStorage({ indexedDB: new IDBFactory() });
+```
+
+<Callout type="warn">
+  When no factory is provided and no global `indexedDB` exists, the constructor
+  throws. Pass a polyfill factory to use it outside the browser.
+</Callout>
+
+## Writing your own adapter
+
+Implementing the two-method contract is enough to target any store — Redis, a
+SQLite blob column, `localStorage`, or a remote HTTP API:
+
+```javascript copy
+class LocalStorageStorage {
+  async get(key) {
+    const value = localStorage.getItem(key);
+    if (value === null) return null;
+    return { body: Uint8Array.from(atob(value), (c) => c.charCodeAt(0)) };
+  }
+
+  async put(key, body) {
+    let binary = "";
+    for (const byte of body) binary += String.fromCharCode(byte);
+    localStorage.setItem(key, btoa(binary));
+    return { etag: "" };
+  }
+}
+
+await persistToStorage(db, new LocalStorageStorage(), "my-index");
+```

--- a/packages/plugin-data-persistence/README.md
+++ b/packages/plugin-data-persistence/README.md
@@ -8,6 +8,36 @@ This plugin aims to provide data persistence capabilities to ZBSearch.
 
 For the complete usage guide, please refer to the [official plugin documentation](https://docs.zbsearch.com/docs/zbsearch-js/plugins/plugin-data-persistence).
 
+## Storage adapters
+
+Besides serializing to a string/buffer (`persist`/`restore`) or to disk
+(`persistToFile`/`restoreFromFile`, via `/server`), you can persist a snapshot
+directly into a pluggable storage backend with `persistToStorage` /
+`restoreFromStorage`. The whole index is written as one compact byte payload;
+the in-memory database is untouched and stays fully queryable, and restoring it
+loads the snapshot back into memory.
+
+Any backend implementing the `PersistenceStorage` contract works. It is
+structurally compatible with `ObjectStorage` from `@zbsearch/edge-core`, so an
+`S3ObjectStorage` can be passed as-is.
+
+```ts
+import { persistToStorage, restoreFromStorage } from '@zbsearch/plugin-data-persistence'
+import { IndexedDBStorage } from '@zbsearch/plugin-data-persistence/indexeddb'
+
+const storage = new IndexedDBStorage() // durable, in-browser
+await persistToStorage(db, storage, 'my-index') // defaults to compact `binary`
+
+// later — e.g. after a page reload:
+const db = await restoreFromStorage(storage, 'my-index')
+```
+
+`persistToStorage(db, storage, key, { format })` and
+`restoreFromStorage(storage, key, { format })` accept the same formats as
+`persist` (`json` | `dpack` | `binary` | `seqproto`); the `format` used to
+restore must match the one used to persist. For IndexedDB, `binary` (raw
+msgpack, no hex doubling) or `json` are recommended.
+
 # License
 
 [Apache-2.0](/LICENSE.md)

--- a/packages/plugin-data-persistence/package.json
+++ b/packages/plugin-data-persistence/package.json
@@ -17,6 +17,10 @@
       "import": "./dist/server.js",
       "require": "./dist/server-commonjs.cjs",
       "node": "./dist/server-commonjs.cjs"
+    },
+    "./indexeddb": {
+      "types": "./dist/indexeddb.d.ts",
+      "import": "./dist/indexeddb.js"
     }
   },
   "types": "./dist/index.d.ts",
@@ -56,6 +60,7 @@
     "@typescript-eslint/parser": "^8.63.0",
     "benny": "^3.7.1",
     "c8": "^7.12.0",
+    "fake-indexeddb": "^6.2.5",
     "msgpack": "link:@types/msgpack/msgpack",
     "readable-stream": "^4.3.0",
     "tap": "^18.6.1",

--- a/packages/plugin-data-persistence/src/errors.ts
+++ b/packages/plugin-data-persistence/src/errors.ts
@@ -10,6 +10,14 @@ export function FILESYSTEM_NOT_SUPPORTED_ON_RUNTIME(runtime: string): string {
   return `Filesystem access is not supported on ${capitalize(runtime)}`
 }
 
+export function STORAGE_KEY_NOT_FOUND(key: string): string {
+  return `No persisted snapshot was found for key "${key}" in the storage backend.`
+}
+
+export function INDEXEDDB_NOT_AVAILABLE(): string {
+  return 'IndexedDB is not available in this environment. Pass a custom `indexedDB` factory (e.g. a polyfill) to IndexedDBStorage.'
+}
+
 export function METHOD_MOVED(method: string): string {
   return `Function ${method} has been moved to the "/server" module. \n\nImport it via "import { ${method} } from 'zbsearch/plugin-data-persistence/server'". \n\nRead more at https://docs.zbsearch.com/docs/zbsearch-js/plugins/plugin-data-persistence.`
 }

--- a/packages/plugin-data-persistence/src/index.ts
+++ b/packages/plugin-data-persistence/src/index.ts
@@ -7,6 +7,13 @@ import { METHOD_MOVED, UNSUPPORTED_FORMAT } from './errors.js'
 import { detectRuntime } from './utils.js'
 import { serializeZBSearchInstance, deserializeZBSearchInstance } from './seqproto.js'
 
+export { persistToStorage, restoreFromStorage } from './storage.js'
+export type {
+  PersistenceStorage,
+  PersistToStorageOptions,
+  RestoreFromStorageOptions
+} from './storage.js'
+
 const hexFromMap: Record<string, number> = {
   0: 0,
   1: 1,

--- a/packages/plugin-data-persistence/src/indexeddb.ts
+++ b/packages/plugin-data-persistence/src/indexeddb.ts
@@ -1,0 +1,120 @@
+import type { PersistenceStorage } from './storage.js'
+import { INDEXEDDB_NOT_AVAILABLE } from './errors.js'
+
+export interface IndexedDBStorageOptions {
+  databaseName?: string
+  storeName?: string
+  indexedDB?: IDBFactory
+}
+
+/**
+ * Durable, in-browser storage backend for ZBSearch snapshots, backed by
+ * IndexedDB. Implements the {@link PersistenceStorage} contract (and the
+ * `delete`/`clear` extras), so it plugs straight into `persistToStorage` /
+ * `restoreFromStorage`:
+ *
+ * ```ts
+ * import { persistToStorage, restoreFromStorage } from '@zbsearch/plugin-data-persistence'
+ * import { IndexedDBStorage } from '@zbsearch/plugin-data-persistence/indexeddb'
+ *
+ * const storage = new IndexedDBStorage()
+ * await persistToStorage(db, storage, 'my-index')
+ * // later, after a reload:
+ * const db = await restoreFromStorage(storage, 'my-index')
+ * ```
+ */
+export class IndexedDBStorage implements PersistenceStorage {
+  private readonly databaseName: string
+  private readonly storeName: string
+  private readonly factory: IDBFactory
+  private dbPromise?: Promise<IDBDatabase>
+
+  constructor(options: IndexedDBStorageOptions = {}) {
+    const factory = options.indexedDB ?? (typeof indexedDB !== 'undefined' ? indexedDB : undefined)
+    if (!factory) {
+      throw new Error(INDEXEDDB_NOT_AVAILABLE())
+    }
+    this.factory = factory
+    this.databaseName = options.databaseName ?? 'zbsearch'
+    this.storeName = options.storeName ?? 'indexes'
+  }
+
+  private openDatabase(): Promise<IDBDatabase> {
+    if (!this.dbPromise) {
+      this.dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+        const request = this.factory.open(this.databaseName)
+
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains(this.storeName)) {
+            database.createObjectStore(this.storeName)
+          }
+        }
+
+        request.onsuccess = () => {
+          const database = request.result
+          // A store name unseen at open time means the existing database was
+          // created without it. Bump the version to trigger onupgradeneeded.
+          if (!database.objectStoreNames.contains(this.storeName)) {
+            const nextVersion = database.version + 1
+            database.close()
+            const upgrade = this.factory.open(this.databaseName, nextVersion)
+            upgrade.onupgradeneeded = () => {
+              upgrade.result.createObjectStore(this.storeName)
+            }
+            upgrade.onsuccess = () => resolve(upgrade.result)
+            upgrade.onerror = () => reject(upgrade.error)
+            return
+          }
+          resolve(database)
+        }
+
+        request.onerror = () => reject(request.error)
+      })
+    }
+    return this.dbPromise
+  }
+
+  private async run<R>(mode: IDBTransactionMode, fn: (store: IDBObjectStore) => IDBRequest<R>): Promise<R> {
+    const database = await this.openDatabase()
+    return new Promise<R>((resolve, reject) => {
+      const transaction = database.transaction(this.storeName, mode)
+      const request = fn(transaction.objectStore(this.storeName))
+      transaction.onabort = () => reject(transaction.error ?? request.error)
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+  }
+
+  async get(key: string): Promise<{ body: Uint8Array } | null> {
+    const value = await this.run<ArrayBuffer | Uint8Array | undefined>('readonly', (store) => store.get(key))
+    if (value === undefined || value === null) {
+      return null
+    }
+    return { body: value instanceof Uint8Array ? value : new Uint8Array(value) }
+  }
+
+  async put(key: string, body: Uint8Array): Promise<{ etag: string }> {
+    // Store a standalone copy so we never persist a view into a larger buffer.
+    const copy = new Uint8Array(body.byteLength)
+    copy.set(body)
+    await this.run('readwrite', (store) => store.put(copy, key))
+    return { etag: '' }
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.run('readwrite', (store) => store.delete(key))
+  }
+
+  async clear(): Promise<void> {
+    await this.run('readwrite', (store) => store.clear())
+  }
+
+  async close(): Promise<void> {
+    if (this.dbPromise) {
+      const database = await this.dbPromise
+      database.close()
+      this.dbPromise = undefined
+    }
+  }
+}

--- a/packages/plugin-data-persistence/src/indexeddb.ts
+++ b/packages/plugin-data-persistence/src/indexeddb.ts
@@ -41,38 +41,52 @@ export class IndexedDBStorage implements PersistenceStorage {
 
   private openDatabase(): Promise<IDBDatabase> {
     if (!this.dbPromise) {
-      this.dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
-        const request = this.factory.open(this.databaseName)
-
-        request.onupgradeneeded = () => {
-          const database = request.result
-          if (!database.objectStoreNames.contains(this.storeName)) {
-            database.createObjectStore(this.storeName)
-          }
+      const pending = this.connect()
+      this.dbPromise = pending
+      // Never keep a rejected connection cached — otherwise a single open
+      // failure would permanently brick the instance. Clear it so a later call
+      // can retry. The original (rejecting) promise is still returned to the
+      // current caller.
+      pending.catch(() => {
+        if (this.dbPromise === pending) {
+          this.dbPromise = undefined
         }
-
-        request.onsuccess = () => {
-          const database = request.result
-          // A store name unseen at open time means the existing database was
-          // created without it. Bump the version to trigger onupgradeneeded.
-          if (!database.objectStoreNames.contains(this.storeName)) {
-            const nextVersion = database.version + 1
-            database.close()
-            const upgrade = this.factory.open(this.databaseName, nextVersion)
-            upgrade.onupgradeneeded = () => {
-              upgrade.result.createObjectStore(this.storeName)
-            }
-            upgrade.onsuccess = () => resolve(upgrade.result)
-            upgrade.onerror = () => reject(upgrade.error)
-            return
-          }
-          resolve(database)
-        }
-
-        request.onerror = () => reject(request.error)
       })
     }
     return this.dbPromise
+  }
+
+  private connect(): Promise<IDBDatabase> {
+    return new Promise<IDBDatabase>((resolve, reject) => {
+      const request = this.factory.open(this.databaseName)
+
+      request.onupgradeneeded = () => {
+        const database = request.result
+        if (!database.objectStoreNames.contains(this.storeName)) {
+          database.createObjectStore(this.storeName)
+        }
+      }
+
+      request.onsuccess = () => {
+        const database = request.result
+        // A store name unseen at open time means the existing database was
+        // created without it. Bump the version to trigger onupgradeneeded.
+        if (!database.objectStoreNames.contains(this.storeName)) {
+          const nextVersion = database.version + 1
+          database.close()
+          const upgrade = this.factory.open(this.databaseName, nextVersion)
+          upgrade.onupgradeneeded = () => {
+            upgrade.result.createObjectStore(this.storeName)
+          }
+          upgrade.onsuccess = () => resolve(upgrade.result)
+          upgrade.onerror = () => reject(upgrade.error)
+          return
+        }
+        resolve(database)
+      }
+
+      request.onerror = () => reject(request.error)
+    })
   }
 
   private async run<R>(mode: IDBTransactionMode, fn: (store: IDBObjectStore) => IDBRequest<R>): Promise<R> {
@@ -111,10 +125,15 @@ export class IndexedDBStorage implements PersistenceStorage {
   }
 
   async close(): Promise<void> {
-    if (this.dbPromise) {
-      const database = await this.dbPromise
-      database.close()
-      this.dbPromise = undefined
+    const pending = this.dbPromise
+    this.dbPromise = undefined
+    if (pending) {
+      try {
+        const database = await pending
+        database.close()
+      } catch {
+        // The connection never opened; there is nothing to close.
+      }
     }
   }
 }

--- a/packages/plugin-data-persistence/src/storage.ts
+++ b/packages/plugin-data-persistence/src/storage.ts
@@ -1,0 +1,131 @@
+import { decode, encode } from '@msgpack/msgpack'
+import type { AnyZBSearch } from 'zbsearch'
+import { create, load, save } from 'zbsearch'
+import * as dpack from './dpack.js'
+import { STORAGE_KEY_NOT_FOUND, UNSUPPORTED_FORMAT } from './errors.js'
+import { serializeZBSearchInstance, deserializeZBSearchInstance } from './seqproto.js'
+import type { PersistenceFormat } from './types.js'
+
+/**
+ * Minimal, byte-oriented storage contract used by `persistToStorage` /
+ * `restoreFromStorage`. It is intentionally structurally compatible with
+ * `ObjectStorage` from `@zbsearch/edge-core`, so an `S3ObjectStorage` (or any
+ * other edge-core storage backend) can be passed directly, with no adapter in
+ * between. Browser backends such as the bundled IndexedDB adapter implement the
+ * same shape.
+ */
+export interface PersistenceStorage {
+  get(key: string, opts?: { ifNoneMatch?: string }): Promise<{ body: Uint8Array } | null>
+  put(key: string, body: Uint8Array, opts?: { contentType?: string }): Promise<unknown>
+}
+
+export interface PersistToStorageOptions {
+  format?: PersistenceFormat
+  /** Passed through to `storage.put` (e.g. for S3/HTTP backends). */
+  contentType?: string
+}
+
+export interface RestoreFromStorageOptions {
+  format?: PersistenceFormat
+}
+
+function toUint8Array(data: string | Uint8Array | ArrayBuffer): Uint8Array {
+  if (data instanceof Uint8Array) {
+    return data
+  }
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data)
+  }
+  return new TextEncoder().encode(data)
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  // Copy into a standalone ArrayBuffer so we never hand out a view into a
+  // larger, pooled buffer (e.g. a Node Buffer backing store).
+  const copy = new Uint8Array(bytes.byteLength)
+  copy.set(bytes)
+  return copy.buffer
+}
+
+/**
+ * Serialize a database into a compact byte payload. Unlike the string-returning
+ * `persist`, the `binary` format here stays as raw msgpack bytes instead of hex,
+ * so persisted payloads are ~half the size.
+ */
+async function serializeToBytes<T extends AnyZBSearch>(db: T, format: PersistenceFormat): Promise<Uint8Array> {
+  switch (format) {
+    case 'json':
+      return new TextEncoder().encode(JSON.stringify(await save(db)))
+    case 'dpack':
+      return toUint8Array(dpack.serialize(await save(db)) as string | Uint8Array | ArrayBuffer)
+    case 'binary':
+      return encode(await save(db))
+    case 'seqproto':
+      return toUint8Array(serializeZBSearchInstance(db) as unknown as ArrayBuffer)
+    default:
+      throw new Error(UNSUPPORTED_FORMAT(format))
+  }
+}
+
+function deserializeFromBytes(format: PersistenceFormat, bytes: Uint8Array): any {
+  switch (format) {
+    case 'json':
+      return JSON.parse(new TextDecoder().decode(bytes))
+    case 'dpack':
+      return dpack.parse(typeof Buffer !== 'undefined' ? Buffer.from(bytes) : (bytes as any))
+    case 'binary':
+      return decode(bytes)
+    case 'seqproto':
+      return deserializeZBSearchInstance(toArrayBuffer(bytes))
+    default:
+      throw new Error(UNSUPPORTED_FORMAT(format))
+  }
+}
+
+/**
+ * Persist a database snapshot into any {@link PersistenceStorage} backend
+ * (IndexedDB, S3/R2, or a custom KV store) under `key`.
+ *
+ * The whole index is serialized and written as one compact byte payload; the
+ * in-memory database is untouched and remains fully queryable. Use
+ * {@link restoreFromStorage} to rebuild it later.
+ */
+export async function persistToStorage<T extends AnyZBSearch>(
+  db: T,
+  storage: PersistenceStorage,
+  key: string,
+  options: PersistToStorageOptions = {}
+): Promise<void> {
+  const format = options.format ?? 'binary'
+  const bytes = await serializeToBytes(db, format)
+  await storage.put(key, bytes, options.contentType ? { contentType: options.contentType } : undefined)
+}
+
+/**
+ * Rebuild a database from a snapshot previously written with
+ * {@link persistToStorage}. The `format` must match the one used to persist.
+ * Throws if `key` does not exist in the backend.
+ */
+export async function restoreFromStorage<T extends AnyZBSearch>(
+  storage: PersistenceStorage,
+  key: string,
+  options: RestoreFromStorageOptions = {}
+): Promise<T> {
+  const format = options.format ?? 'binary'
+  const result = await storage.get(key)
+
+  if (!result) {
+    throw new Error(STORAGE_KEY_NOT_FOUND(key))
+  }
+
+  const deserialized = deserializeFromBytes(format, toUint8Array(result.body))
+
+  const db = create({
+    schema: {
+      __placeholder: 'string'
+    }
+  })
+  load(db, deserialized)
+
+  return db as unknown as T
+}

--- a/packages/plugin-data-persistence/test/storage.test.ts
+++ b/packages/plugin-data-persistence/test/storage.test.ts
@@ -1,0 +1,147 @@
+import { create, insert, search } from 'zbsearch'
+import t from 'tap'
+import { persistToStorage, restoreFromStorage } from '../src/storage.js'
+import type { PersistenceStorage } from '../src/storage.js'
+import { IndexedDBStorage } from '../src/indexeddb.js'
+import { STORAGE_KEY_NOT_FOUND, INDEXEDDB_NOT_AVAILABLE } from '../src/errors.js'
+import type { PersistenceFormat } from '../src/types.js'
+
+// In-memory storage backend implementing the PersistenceStorage contract.
+// Records byte payloads so we can assert on what was written.
+class MemoryStorage implements PersistenceStorage {
+  store = new Map<string, Uint8Array>()
+
+  async get(key: string): Promise<{ body: Uint8Array } | null> {
+    const body = this.store.get(key)
+    return body ? { body } : null
+  }
+
+  async put(key: string, body: Uint8Array): Promise<{ etag: string }> {
+    this.store.set(key, body)
+    return { etag: '' }
+  }
+}
+
+async function generateTestDBInstance() {
+  const db = await create({
+    schema: {
+      quote: 'string',
+      author: 'string'
+    } as const
+  })
+
+  await insert(db, { quote: 'The only way to do great work is to love what you do.', author: 'Steve Jobs' })
+  await insert(db, { quote: 'I have not failed. I have found 10,000 ways that will not work.', author: 'Thomas A. Edison' })
+  await insert(db, { quote: 'Be yourself; everyone else is already taken.', author: 'Oscar Wilde' })
+
+  return db
+}
+
+const formats: PersistenceFormat[] = ['json', 'dpack', 'binary', 'seqproto']
+
+t.test('persistToStorage / restoreFromStorage', async (t) => {
+  t.plan(formats.length + 3)
+
+  for (const format of formats) {
+    t.test(`round-trips through a storage backend (${format})`, async (t) => {
+      t.plan(3)
+      const db = await generateTestDBInstance()
+      const original = await search(db, { mode: 'fulltext', term: 'way' })
+
+      const storage = new MemoryStorage()
+      await persistToStorage(db, storage, 'my-index', { format })
+
+      t.ok(storage.store.has('my-index'), 'wrote a payload under the key')
+
+      const restored = await restoreFromStorage(storage, 'my-index', { format })
+      const restoredResults = await search(restored, { mode: 'fulltext', term: 'way' })
+
+      t.equal(restoredResults.count, original.count, 'same hit count after restore')
+      t.same(
+        restoredResults.hits.map((h) => h.id),
+        original.hits.map((h) => h.id),
+        'same hit ids after restore'
+      )
+    })
+  }
+
+  t.test('defaults to the compact binary format (no hex doubling)', async (t) => {
+    t.plan(1)
+    const db = await generateTestDBInstance()
+    const storage = new MemoryStorage()
+    await persistToStorage(db, storage, 'default-format')
+    // The binary format used to be persisted as a hex string (2 chars/byte).
+    // Raw msgpack bytes must be materially smaller than that hex encoding.
+    const jsonStorage = new MemoryStorage()
+    await persistToStorage(db, jsonStorage, 'as-json', { format: 'json' })
+    const binarySize = storage.store.get('default-format')!.byteLength
+    const jsonSize = jsonStorage.store.get('as-json')!.byteLength
+    t.ok(binarySize < jsonSize, `binary (${binarySize}B) should be smaller than json (${jsonSize}B)`)
+  })
+
+  t.test('throws a clear error when the key is missing', async (t) => {
+    t.plan(1)
+    const storage = new MemoryStorage()
+    await t.rejects(restoreFromStorage(storage, 'nope'), new Error(STORAGE_KEY_NOT_FOUND('nope')))
+  })
+
+  t.test('restore respects a non-default format', async (t) => {
+    t.plan(1)
+    const db = await generateTestDBInstance()
+    const storage = new MemoryStorage()
+    await persistToStorage(db, storage, 'k', { format: 'json' })
+    const restored = await restoreFromStorage(storage, 'k', { format: 'json' })
+    const results = await search(restored, { mode: 'fulltext', term: 'yourself' })
+    t.equal(results.count, 1, 'restored index is queryable')
+  })
+})
+
+t.test('IndexedDBStorage', async (t) => {
+  let fakeFactory: IDBFactory | undefined
+  try {
+    // fake-indexeddb ships an IDBFactory we can inject without touching globals.
+    const mod = await import('fake-indexeddb')
+    fakeFactory = new (mod.IDBFactory ?? (mod as any).default)()
+  } catch {
+    fakeFactory = undefined
+  }
+
+  t.test('throws when IndexedDB is unavailable and no factory is given', async (t) => {
+    t.plan(1)
+    const savedGlobal = (globalThis as any).indexedDB
+    // Ensure no ambient indexedDB leaks into the constructor.
+    delete (globalThis as any).indexedDB
+    t.throws(() => new IndexedDBStorage(), new Error(INDEXEDDB_NOT_AVAILABLE()))
+    if (savedGlobal !== undefined) {
+      ;(globalThis as any).indexedDB = savedGlobal
+    }
+  })
+
+  if (!fakeFactory) {
+    t.comment('fake-indexeddb not installed — skipping IndexedDB round-trip test')
+    return
+  }
+
+  t.test('round-trips a database through IndexedDB', async (t) => {
+    t.plan(3)
+    const db = await generateTestDBInstance()
+    const original = await search(db, { mode: 'fulltext', term: 'way' })
+
+    const storage = new IndexedDBStorage({ indexedDB: fakeFactory })
+    await persistToStorage(db, storage, 'idb-index')
+
+    const restored = await restoreFromStorage(storage, 'idb-index')
+    const restoredResults = await search(restored, { mode: 'fulltext', term: 'way' })
+
+    t.equal(restoredResults.count, original.count, 'same hit count after restore')
+
+    // get on a missing key returns null (surfaced as a clear restore error)
+    await t.rejects(restoreFromStorage(storage, 'missing'), new Error(STORAGE_KEY_NOT_FOUND('missing')))
+
+    await storage.delete('idb-index')
+    const afterDelete = await storage.get('idb-index')
+    t.equal(afterDelete, null, 'delete removes the snapshot')
+
+    await storage.close()
+  })
+})

--- a/packages/plugin-data-persistence/test/storage.test.ts
+++ b/packages/plugin-data-persistence/test/storage.test.ts
@@ -122,6 +122,38 @@ t.test('IndexedDBStorage', async (t) => {
     return
   }
 
+  t.test('recovers after an open failure instead of bricking', async (t) => {
+    t.plan(2)
+
+    // A factory whose first open() fails, then delegates to the real one.
+    let failedOnce = false
+    const flakyFactory = {
+      open(name: string, version?: number) {
+        if (!failedOnce) {
+          failedOnce = true
+          const request: any = { onerror: null, onsuccess: null, onupgradeneeded: null, error: new Error('boom') }
+          Promise.resolve().then(() => request.onerror && request.onerror())
+          return request
+        }
+        return (fakeFactory as IDBFactory).open(name, version)
+      }
+    } as unknown as IDBFactory
+
+    const storage = new IndexedDBStorage({ indexedDB: flakyFactory })
+
+    // First operation fails because the initial open() errors...
+    await t.rejects(storage.get('anything'), 'first open rejects')
+
+    // ...but the instance must not be permanently bricked: a retry re-opens.
+    const db = await generateTestDBInstance()
+    await persistToStorage(db, storage, 'after-recovery')
+    const restored = await restoreFromStorage(storage, 'after-recovery')
+    const results = await search(restored, { mode: 'fulltext', term: 'yourself' })
+    t.equal(results.count, 1, 'instance recovered and round-trips after the failure')
+
+    await storage.close()
+  })
+
   t.test('round-trips a database through IndexedDB', async (t) => {
     t.plan(3)
     const db = await generateTestDBInstance()

--- a/packages/storage-s3/package.json
+++ b/packages/storage-s3/package.json
@@ -12,7 +12,9 @@
     }
   },
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "swc --delete-dir-on-start --extensions .ts -d dist src && tsc -p . --emitDeclarationOnly",
     "test": "node --import tsx --test tests/**/*.test.ts"
@@ -26,7 +28,9 @@
     "@swc/cli": "^0.1.59",
     "@swc/core": "^1.3.27",
     "@types/node": "^20.19.43",
+    "@zbsearch/plugin-data-persistence": "workspace:*",
     "tsx": "^4.20.6",
-    "typescript": "npm:@typescript/typescript6@^6.0.2"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "zbsearch": "workspace:*"
   }
 }

--- a/packages/storage-s3/tests/persistence-integration.test.ts
+++ b/packages/storage-s3/tests/persistence-integration.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { create, insert, search } from 'zbsearch'
+import { persistToStorage, restoreFromStorage } from '@zbsearch/plugin-data-persistence'
+
+import { S3ObjectStorage } from '../src/index.js'
+import { MockS3Backend } from './mock-s3.js'
+
+// Proves that S3ObjectStorage satisfies the plugin's PersistenceStorage contract
+// out of the box, so `persistToStorage` / `restoreFromStorage` work against S3/R2
+// with no adapter in between.
+
+async function generateTestDBInstance() {
+  const db = await create({
+    schema: {
+      quote: 'string',
+      author: 'string'
+    } as const
+  })
+
+  await insert(db, { quote: 'He who is brave is free', author: 'Seneca' })
+  await insert(db, { quote: 'Make each day your masterpiece', author: 'John Wooden' })
+  await insert(db, { quote: 'You must be the change you wish to see in the world', author: 'Mahatma Gandhi' })
+
+  return db
+}
+
+function makeStorage() {
+  const backend = new MockS3Backend()
+  const storage = new S3ObjectStorage({
+    bucket: 'b',
+    accessKeyId: 'k',
+    secretAccessKey: 's',
+    client: backend.createClient('b')
+  })
+  return { backend, storage }
+}
+
+describe('persistToStorage / restoreFromStorage with S3ObjectStorage', () => {
+  it('round-trips a database through S3 (default binary format)', async () => {
+    const db = await generateTestDBInstance()
+    const original = await search(db, { term: 'brave' })
+
+    const { backend, storage } = makeStorage()
+    await persistToStorage(db, storage, 'indexes/quotes.msp')
+
+    // The snapshot is stored under the exact key we asked for.
+    assert.ok(backend.objects.has('indexes/quotes.msp'))
+
+    const restored = await restoreFromStorage(storage, 'indexes/quotes.msp')
+    const restoredResults = await search(restored, { term: 'brave' })
+
+    assert.equal(restoredResults.count, original.count)
+    assert.deepEqual(
+      restoredResults.hits.map((h) => h.id),
+      original.hits.map((h) => h.id)
+    )
+  })
+
+  it('round-trips using the json format', async () => {
+    const db = await generateTestDBInstance()
+    const { storage } = makeStorage()
+
+    await persistToStorage(db, storage, 'quotes.json', { format: 'json' })
+    const restored = await restoreFromStorage(storage, 'quotes.json', { format: 'json' })
+
+    const results = await search(restored, { term: 'masterpiece' })
+    assert.equal(results.count, 1)
+  })
+
+  it('forwards contentType through to S3', async () => {
+    const db = await generateTestDBInstance()
+    const { backend, storage } = makeStorage()
+
+    await persistToStorage(db, storage, 'quotes.json', { format: 'json', contentType: 'application/json' })
+    assert.equal(backend.objects.get('quotes.json')?.contentType, 'application/json')
+  })
+
+  it('throws a clear error when the key does not exist', async () => {
+    const { storage } = makeStorage()
+    await assert.rejects(restoreFromStorage(storage, 'missing'), /No persisted snapshot was found for key "missing"/)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,12 @@ importers:
       '@orama/orama':
         specifier: ^3.1.18
         version: 3.1.18
+      '@orama/stemmers':
+        specifier: ^3.1.18
+        version: 3.1.18
+      '@orama/stopwords':
+        specifier: ^3.1.18
+        version: 3.1.18
       '@zbsearch/plugin-pt15':
         specifier: file:../packages/plugin-pt15
         version: file:packages/plugin-pt15
@@ -275,6 +281,9 @@ importers:
       c8:
         specifier: ^7.12.0
         version: 7.14.0
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       msgpack:
         specifier: link:@types/msgpack/msgpack
         version: link:@types/msgpack/msgpack
@@ -519,12 +528,18 @@ importers:
       '@types/node':
         specifier: ^20.19.43
         version: 20.19.43
+      '@zbsearch/plugin-data-persistence':
+        specifier: workspace:*
+        version: link:../plugin-data-persistence
       tsx:
         specifier: ^4.20.6
         version: 4.22.4
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
+      zbsearch:
+        specifier: workspace:*
+        version: link:../zbsearch
 
   packages/tokenizers:
     dependencies:
@@ -1902,6 +1917,14 @@ packages:
 
   '@orama/orama@3.1.18':
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
+    engines: {node: '>= 20.0.0'}
+
+  '@orama/stemmers@3.1.18':
+    resolution: {integrity: sha512-xXs5fpiUvBs4jJZtnayJmUSomdxxiwwwvTbAzPHSyI6geLM7bxXHgpVlYz4JeMBycHX8bHF7j9m7F35BxhuZ8g==}
+    engines: {node: '>= 20.0.0'}
+
+  '@orama/stopwords@3.1.18':
+    resolution: {integrity: sha512-W8V7m7RnCme+99OmKl/xs5rf6OUhFpr0aPGVmPrXzTLSg4ZqSbRY2euS2S/lgjjYi/0NhEWqwoq8nDY6Ihx4EA==}
     engines: {node: '>= 20.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
@@ -4784,6 +4807,10 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -9686,6 +9713,10 @@ snapshots:
 
   '@orama/orama@3.1.18': {}
 
+  '@orama/stemmers@3.1.18': {}
+
+  '@orama/stopwords@3.1.18': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -10589,6 +10620,16 @@ snapshots:
     dependencies:
       '@tapjs/core': 4.5.8(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
+  '@tapjs/config@2.4.19(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+    dependencies:
+      '@tapjs/core': 1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/test': 1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      chalk: 5.6.2
+      jackspeak: 2.3.6
+      polite-json: 4.0.1
+      tap-yaml: 2.2.2
+      walk-up-path: 3.0.1
+
   '@tapjs/config@2.4.19(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
       '@tapjs/core': 1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -10843,6 +10884,30 @@ snapshots:
       signal-exit: 4.1.0
       uuid: 14.0.1
 
+  '@tapjs/reporter@1.3.20(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))':
+    dependencies:
+      '@tapjs/config': 2.4.19(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/stack': 1.2.8
+      chalk: 5.6.2
+      ink: 4.4.1(@types/react@19.2.17)(react@18.3.1)
+      minipass: 7.1.3
+      ms: 2.1.3
+      patch-console: 2.0.0
+      prismjs-terminal: 1.2.3
+      react: 18.3.1
+      string-length: 6.0.0
+      tap-parser: 15.3.2
+      tap-yaml: 2.2.2
+      tcompare: 6.4.6(react-dom@19.2.7(react@19.2.7))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@tapjs/test'
+      - '@types/react'
+      - bufferutil
+      - react-devtools-core
+      - react-dom
+      - utf-8-validate
+
   '@tapjs/reporter@1.3.20(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))':
     dependencies:
       '@tapjs/config': 2.4.19(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
@@ -10913,6 +10978,48 @@ snapshots:
       - bufferutil
       - react-devtools-core
       - react-dom
+      - utf-8-validate
+
+  '@tapjs/run@1.5.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tapjs/after': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/before': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/config': 2.4.19(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/processinfo': 3.1.12
+      '@tapjs/reporter': 1.3.20(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))
+      '@tapjs/spawn': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/stdin': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/test': 1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      c8: 8.0.1
+      chalk: 5.6.2
+      chokidar: 3.6.0
+      foreground-child: 3.3.1
+      glob: 10.4.5
+      minipass: 7.1.3
+      mkdirp: 3.0.1
+      opener: 1.5.2
+      pacote: 17.0.7
+      resolve-import: 1.4.6
+      rimraf: 5.0.10
+      semver: 7.8.5
+      signal-exit: 4.1.0
+      tap-parser: 15.3.2
+      tap-yaml: 2.2.2
+      tcompare: 6.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      trivial-deferred: 2.0.0
+      which: 4.0.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - '@types/react'
+      - bluebird
+      - bufferutil
+      - react
+      - react-devtools-core
+      - react-dom
+      - supports-color
       - utf-8-validate
 
   '@tapjs/run@1.5.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
@@ -11354,6 +11461,16 @@ snapshots:
       - '@types/node'
       - typescript
 
+  '@tapjs/typescript@1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(typescript@7.0.2)':
+    dependencies:
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43)(@types/node@20.19.43)(typescript@7.0.2)
+      '@tapjs/core': 1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - typescript
+
   '@tapjs/typescript@1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(@typescript/typescript6@6.0.2)':
     dependencies:
       '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43)(@types/node@20.19.43)(@typescript/typescript6@6.0.2)
@@ -11367,16 +11484,6 @@ snapshots:
   '@tapjs/typescript@1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(typescript@5.2.2)':
     dependencies:
       '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43)(@types/node@20.19.43)(typescript@5.2.2)
-      '@tapjs/core': 1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - typescript
-
-  '@tapjs/typescript@1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(typescript@7.0.2)':
-    dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43)(@types/node@20.19.43)(typescript@7.0.2)
       '@tapjs/core': 1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@swc/core'
@@ -13534,6 +13641,8 @@ snapshots:
       sort-keys-length: 1.0.1
 
   extend@3.0.2: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -17618,24 +17727,24 @@ snapshots:
 
   tap@18.8.0(@swc/core@1.15.43)(@types/node@20.19.43)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2):
     dependencies:
-      '@tapjs/after': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/after-each': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/asserts': 1.2.0(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/before': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/before-each': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/after': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/after-each': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/asserts': 1.2.0(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/before': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/before-each': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@tapjs/core': 1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/filter': 1.2.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/fixture': 1.2.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/intercept': 1.2.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/mock': 1.3.4(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/node-serialize': 1.3.4(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/run': 1.5.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/snapshot': 1.2.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/spawn': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/stdin': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/test': 1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/typescript': 1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(typescript@7.0.2)
-      '@tapjs/worker': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@24.13.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/filter': 1.2.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/fixture': 1.2.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/intercept': 1.2.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/mock': 1.3.4(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/node-serialize': 1.3.4(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/run': 1.5.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/snapshot': 1.2.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/spawn': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/stdin': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/test': 1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/typescript': 1.4.4(@swc/core@1.15.43)(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@20.19.43)(typescript@7.0.2)
+      '@tapjs/worker': 1.1.22(@tapjs/core@1.5.4(@swc/core@1.15.43)(@types/node@20.19.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       resolve-import: 1.4.6
     transitivePeerDependencies:
       - '@swc/core'


### PR DESCRIPTION
cursor review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New persistence paths affect how indexes are serialized and restored across environments; format mismatches or corrupt snapshots could break cold-start restores, though behavior is covered by tests and errors on missing keys.
> 
> **Overview**
> Adds **pluggable snapshot persistence** via `persistToStorage` / `restoreFromStorage`, so a full in-memory index can be written to and restored from any backend that implements the `PersistenceStorage` contract (`get` / `put` on byte payloads).
> 
> The default **`binary`** format stores **raw msgpack** (not hex), roughly halving payload size versus string `persist`. Formats `json`, `dpack`, and `seqproto` are supported; restore must use the same format. Missing keys throw a dedicated error.
> 
> Ships **`IndexedDBStorage`** under `@zbsearch/plugin-data-persistence/indexeddb` for durable browser snapshots (optional polyfill factory for tests/SSR), plus docs for **S3/R2/MinIO** via existing `S3ObjectStorage` without an adapter. README and a new **Storage Adapters** doc page cover the API and custom adapters.
> 
> Coverage includes unit tests (all formats, IndexedDB with `fake-indexeddb`) and an **S3 integration test** proving round-trip and `contentType` forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d737505818b51d7d52ad3ac4a8f9d0f80f78fa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->