### PR TITLE
Adds suggestions APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ After [Michele's departure](https://www.micheleriva.dev/writings/my-last-day-at-
 # Highlighted features
 
 - [Full-Text search](https://zbsearch.dev/docs/zbsearch/search)
+- [Autocomplete / Autosuggest](https://zbsearch.dev/docs/zbsearch/search/autocomplete)
 - [Vector Search](https://zbsearch.dev/docs/zbsearch/search/vector-search)
 - [Hybrid Search](https://zbsearch.dev/docs/zbsearch/search/hybrid-search)
 - [Search Filters](https://zbsearch.dev/docs/zbsearch/search/filters)

--- a/apps/docs/content/docs/zbsearch/search/autocomplete.mdx
+++ b/apps/docs/content/docs/zbsearch/search/autocomplete.mdx
@@ -1,0 +1,225 @@
+---
+title: Autocomplete
+description: The suggest function returns ranked query completions for a partially typed term, to power autocomplete dropdowns.
+---
+
+Autocomplete dropdowns are one of the most common search-UI needs: as the user types, you want to
+show them the queries they could run, not the documents themselves.
+
+The `suggest` function (also exported as `autoSuggest`) returns the **ranked query completions** for
+a partially typed term. It expands each word of the term into the indexed words that start with it,
+groups the results by completion, and ranks them by the aggregated relevance of the documents each
+completion was found in.
+
+## Usage
+
+```javascript
+import { create, insertMultiple, suggest } from "zbsearch";
+
+const db = create({
+  schema: {
+    title: "string",
+    description: "string",
+    price: "number",
+  },
+});
+
+insertMultiple(db, [
+  {
+    title: "Noise cancelling headphones",
+    description: "Wireless over-ear headphones",
+    price: 299,
+  },
+  {
+    title: "Noise cancelling earbuds",
+    description: "Active noise cancellation, in-ear",
+    price: 199,
+  },
+  {
+    title: "Wired headphones",
+    description: "Cheap headphones for the office",
+    price: 30,
+  },
+]);
+
+const results = suggest(db, {
+  term: "head",
+});
+
+console.log(results);
+
+// {
+//   elapsed: {
+//     raw: 404291,
+//     formatted: '404μs'
+//   },
+//   count: 1,
+//   suggestions: [
+//     {
+//       suggestion: 'headphones',
+//       terms: [ 'headphones' ],
+//       score: 1.1785686090842307,
+//       count: 2
+//     }
+//   ]
+// }
+```
+
+Every suggestion contains:
+
+| Property     | Type       | Description                                                                                  |
+| ------------ | ---------- | -------------------------------------------------------------------------------------------- |
+| `suggestion` | `string`   | The suggested completion, ready to be used as the term of a `search` call.                    |
+| `terms`      | `string[]` | The indexed words the suggestion is made of, one per word of the searched term.               |
+| `score`      | `number`   | The aggregated relevance of the documents the suggestion was found in.                        |
+| `count`      | `number`   | How many documents the suggestion was found in.                                              |
+
+The `count` at the root of the response is the total number of suggestions found, ignoring `limit`
+and `offset`.
+
+## Completing a phrase
+
+A term can contain several words. The last one is the word being completed, the previous ones are
+its context: only the completions that actually appear in the same document as that context are
+suggested.
+
+```javascript
+const results = suggest(db, {
+  term: "noise can",
+});
+
+console.log(results.suggestions);
+
+// [
+//   {
+//     suggestion: 'noise cancelling',
+//     terms: [ 'noise', 'cancelling' ],
+//     score: 2.301266980625318,
+//     count: 2
+//   },
+//   {
+//     suggestion: 'noise cancellation',
+//     terms: [ 'noise', 'cancellation' ],
+//     score: 1.80561748849886,
+//     count: 1
+//   }
+// ]
+```
+
+`"noise cancelling"` comes first because it leads to more, and more relevant, documents than
+`"noise cancellation"`. No suggestion mixes words coming from different documents, so the user never
+sees a completion that returns no result.
+
+## Parameters
+
+`suggest` accepts the same relevant options as [search](/docs/zbsearch/search):
+
+| Property     | Type                       | Default | Description                                                                     |
+| ------------ | -------------------------- | ------- | ------------------------------------------------------------------------------- |
+| `term`       | `string`                   | -       | The partially typed term to complete.                                            |
+| `properties` | `'*' \| string[]`          | `'*'`   | The properties to take the suggestions from.                                     |
+| `limit`      | `number`                   | `10`    | The number of suggestions to return.                                             |
+| `offset`     | `number`                   | `0`     | The number of suggestions to skip.                                               |
+| `prefix`     | `boolean \| 'last'`        | `true`  | Which words of the term are prefix-expanded.                                     |
+| `tolerance`  | `number`                   | `0`     | The maximum Levenshtein distance between a typed word and a suggested one.        |
+| `boost`      | `Record<string, number>`   | `{}`    | The [boost](/docs/zbsearch/search/fields-boosting) to apply to each property.     |
+| `where`      | `WhereCondition`           | -       | Only aggregate the suggestions from the documents matching these [filters](/docs/zbsearch/search/filters). |
+| `relevance`  | `BM25Params`               | -       | The [BM25](/docs/zbsearch/search/bm25) parameters used to score the documents.    |
+| `threshold`  | `number`                   | `0`     | How many words of the term a document must match to contribute a suggestion.     |
+
+### Restricting and boosting properties
+
+Suggestions can be taken from a subset of the schema, and the properties can be boosted exactly as
+in `search`, to promote the completions found in the most important ones:
+
+```javascript
+const results = suggest(db, {
+  term: "head",
+  properties: ["title"],
+  boost: {
+    title: 2,
+  },
+});
+```
+
+### Filtering
+
+Only the documents matching the `where` filters contribute their words, so the suggestions always
+lead to a result within the current filters:
+
+```javascript
+const results = suggest(db, {
+  term: "head",
+  where: {
+    price: {
+      lt: 100,
+    },
+  },
+});
+
+console.log(results.suggestions);
+
+// [
+//   {
+//     suggestion: 'headphones',
+//     terms: [ 'headphones' ],
+//     score: 0.5829198084759848,
+//     count: 1
+//   }
+// ]
+```
+
+### Prefix expansion
+
+The `prefix` property controls which words of the term are expanded:
+
+- `true` (default): every word is expanded, so `"noi can"` suggests `"noise cancelling"`.
+- `'last'`: only the last word is expanded, the previous ones must match a whole indexed word. This
+  is the cheapest option, and the most accurate one when the user is typing left to right.
+- `false`: no expansion at all, only whole indexed words are matched. Useful together with
+  `tolerance` to suggest the correction of a fully typed query.
+
+### Typo tolerance
+
+Set a `tolerance` to suggest completions for a misspelled term, as `"hedphones"` for
+`"headphones"`:
+
+```javascript
+const results = suggest(db, {
+  term: "hedphones",
+  tolerance: 1,
+});
+
+console.log(results.suggestions);
+
+// [
+//   {
+//     suggestion: 'headphones',
+//     terms: [ 'headphones' ],
+//     score: 1.1785686090842307,
+//     count: 2
+//   }
+// ]
+```
+
+The tolerance is the maximum [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)
+between the typed word and the suggested one, exactly as in `search`.
+
+### Threshold
+
+By default a document only contributes a suggestion when it matches **every** word of the term. Set
+a [threshold](/docs/zbsearch/search/threshold) greater than `0` to also aggregate the partially
+matching documents; the words with no match are kept verbatim in the returned suggestion.
+
+## Suggestions are indexed words
+
+Suggestions come from the index, so they went through the same
+[text analysis](/docs/zbsearch/text-analysis/stemming) as the documents. With a stemmer configured,
+the suggested words are stems, and with stop words enabled the term's stop words are dropped from
+the suggestion.
+
+If you need the original text of the documents instead, run a `search` and read the `hits`.
+
+<Callout title='Custom index components'>
+`suggest` needs to expand a query word into the indexed words it matches, which the default index component does through its radix tree. A custom index component that cannot do so — like the ones shipped by the [QPS](/docs/zbsearch/plugins/plugin-qps) and [PT15](/docs/zbsearch/plugins/plugin-pt15) plugins — makes `suggest` throw a `SUGGEST_NOT_SUPPORTED` error.
+</Callout>

--- a/apps/docs/content/docs/zbsearch/search/index.mdx
+++ b/apps/docs/content/docs/zbsearch/search/index.mdx
@@ -190,6 +190,24 @@ of `1` (e.g. `Chris`) in the `director` property.
 `tolerance` doesn't work together with the `exact` parameter. `exact` will have priority.
 </Callout>
 
+## Autocomplete
+
+`search` returns documents. When you need the **queries** the user could run instead — to fill an
+autocomplete dropdown as they type — use the `suggest` function, which returns ranked query
+completions built from the indexed words:
+
+```javascript copy
+import { suggest } from "zbsearch";
+
+const results = suggest(movieDB, {
+  term: "Chri",
+});
+
+// results.suggestions = [{ suggestion: 'chris', terms: ['chris'], score: 2.1, count: 3 }, ...]
+```
+
+Read the [autocomplete](/docs/zbsearch/search/autocomplete) documentation for the full API.
+
 ## Results limits
 
 The `limit` property limits the result at the specified number.

--- a/apps/docs/content/docs/zbsearch/search/meta.json
+++ b/apps/docs/content/docs/zbsearch/search/meta.json
@@ -2,6 +2,7 @@
 	"title": "Search",
 	"pages": [
 		"index",
+		"autocomplete",
 		"changing-default-search-algorithm",
 		"vector-search",
 		"hybrid-search",

--- a/packages/zbsearch/README.md
+++ b/packages/zbsearch/README.md
@@ -16,6 +16,7 @@ After [Michele's departure](https://www.micheleriva.dev/writings/my-last-day-at-
 # Highlighted features
 
 - [Full-Text search](https://zbsearch.dev/docs/zbsearch/search)
+- [Autocomplete / Autosuggest](https://zbsearch.dev/docs/zbsearch/search/autocomplete)
 - [Vector Search](https://zbsearch.dev/docs/zbsearch/search/vector-search)
 - [Hybrid Search](https://zbsearch.dev/docs/zbsearch/search/hybrid-search)
 - [Search Filters](https://zbsearch.dev/docs/zbsearch/search/filters)

--- a/packages/zbsearch/src/components/index.ts
+++ b/packages/zbsearch/src/components/index.ts
@@ -32,6 +32,7 @@ import type {
 import { convertDistanceToMeters, setDifference, setIntersection, setUnion } from '../utils.js'
 import { BM25 } from './algorithms.js'
 import { getInnerType, getVectorSize, isArrayType, isVectorType } from './defaults.js'
+import { levenshtein } from './levenshtein.js'
 import {
   DocumentID,
   getInternalDocumentId,
@@ -839,7 +840,12 @@ export function searchSuggestions(
 
     for (let i = 0; i < tokenCount; i++) {
       const { token, exact, tolerance, completion } = queryTokens[i]
-      const searchResult = (tree.node as RadixTree).find({ term: token, exact, tolerance })
+      const wholeWordWithTolerance = exact && tolerance > 0
+      const searchResult = (tree.node as RadixTree).find({
+        term: token,
+        exact: exact && !wholeWordWithTolerance,
+        tolerance
+      })
       const words = Object.keys(searchResult)
       const tokenDocumentFrequency = searchResult[token]?.length
 
@@ -847,6 +853,14 @@ export function searchSuggestions(
         const word = words[j]
         const ids = searchResult[word]
         if (!ids.length) {
+          continue
+        }
+
+        if (
+          wholeWordWithTolerance &&
+          word !== token &&
+          (Math.abs(word.length - token.length) > tolerance || levenshtein(token, word) > tolerance)
+        ) {
           continue
         }
 
@@ -1235,7 +1249,7 @@ export function createIndex(): IIndex<Index> {
     removeTokenScoreParameters,
     calculateResultScores,
     search,
-    searchSuggestions,
+    supportsSuggestions: true,
     searchByWhereClause,
     getSearchableProperties,
     getSearchablePropertiesWithTypes,

--- a/packages/zbsearch/src/components/index.ts
+++ b/packages/zbsearch/src/components/index.ts
@@ -23,6 +23,8 @@ import type {
   ScalarSearchableType,
   SearchableType,
   SearchableValue,
+  SuggestionDocumentMatch,
+  SuggestionQueryToken,
   Tokenizer,
   TokenScore,
   WhereCondition
@@ -804,6 +806,98 @@ export function search(
   return results
 }
 
+export function searchSuggestions(
+  index: Index,
+  queryTokens: SuggestionQueryToken[],
+  propertiesToSearch: string[],
+  boost: Record<string, number>,
+  relevance: Required<BM25Params>,
+  docsCount: number,
+  whereFiltersIDs: Set<InternalDocumentID> | undefined
+): Map<InternalDocumentID, SuggestionDocumentMatch> {
+  const matches = new Map<InternalDocumentID, SuggestionDocumentMatch>()
+  const tokenCount = queryTokens.length
+
+  for (const prop of propertiesToSearch) {
+    if (!(prop in index.indexes)) {
+      continue
+    }
+
+    const tree = index.indexes[prop]
+    if (tree.type !== 'Radix') {
+      throw createError('WRONG_SEARCH_PROPERTY_TYPE', prop)
+    }
+
+    const boostPerProperty = boost[prop] ?? 1
+    if (boostPerProperty <= 0) {
+      throw createError('INVALID_BOOST_VALUE', boostPerProperty)
+    }
+
+    const avgFieldLength = index.avgFieldLength[prop]
+    const fieldLengths = index.fieldLengths[prop]
+    const frequencies = index.frequencies[prop]
+
+    for (let i = 0; i < tokenCount; i++) {
+      const { token, exact, tolerance, completion } = queryTokens[i]
+      const searchResult = (tree.node as RadixTree).find({ term: token, exact, tolerance })
+      const words = Object.keys(searchResult)
+      const tokenDocumentFrequency = searchResult[token]?.length
+
+      for (let j = 0; j < words.length; j++) {
+        const word = words[j]
+        const ids = searchResult[word]
+        if (!ids.length) {
+          continue
+        }
+
+        const wordBoost =
+          boostPerProperty *
+          (word === token ? 1 : prefixExpansionDemotion(tokenDocumentFrequency, ids.length, docsCount))
+        const termOccurrences = getTermDocumentFrequency(index, prop, word)
+
+        for (let k = 0; k < ids.length; k++) {
+          const internalId = ids[k]
+          if (whereFiltersIDs && !whereFiltersIDs.has(internalId)) {
+            continue
+          }
+
+          const tf = frequencies?.[internalId]?.[word] ?? 0
+          const score =
+            BM25(tf, termOccurrences, docsCount, fieldLengths[internalId]!, avgFieldLength, relevance) * wordBoost
+
+          let match = matches.get(internalId)
+          if (!match) {
+            match = {
+              words: new Array<string | undefined>(tokenCount).fill(undefined),
+              wordScores: new Array<number>(tokenCount).fill(0),
+              matchedTokens: 0,
+              score: 0
+            }
+            matches.set(internalId, match)
+          }
+
+          match.score += score
+
+          if (completion) {
+            const completions = match.completions ?? (match.completions = new Map<string, number>())
+            completions.set(word, (completions.get(word) ?? 0) + score)
+          }
+
+          if (match.words[i] === undefined || score > match.wordScores[i]) {
+            if (match.words[i] === undefined) {
+              match.matchedTokens++
+            }
+            match.words[i] = word
+            match.wordScores[i] = score
+          }
+        }
+      }
+    }
+  }
+
+  return matches
+}
+
 export function searchByWhereClause<T extends AnyZBSearch>(
   index: Index,
   tokenizer: Tokenizer,
@@ -1141,6 +1235,7 @@ export function createIndex(): IIndex<Index> {
     removeTokenScoreParameters,
     calculateResultScores,
     search,
+    searchSuggestions,
     searchByWhereClause,
     getSearchableProperties,
     getSearchablePropertiesWithTypes,

--- a/packages/zbsearch/src/errors.ts
+++ b/packages/zbsearch/src/errors.ts
@@ -46,7 +46,8 @@ const errors = {
   ANSWER_SESSION_LAST_MESSAGE_IS_NOT_ASSISTANT: `The last message in the session is not an assistant message. Cannot regenerate non-assistant messages.`,
   PLUGIN_COMPONENT_CONFLICT: `The component "%s" is already defined. The plugin "%s" is trying to redefine it.`,
   IVF_INDEX_REQUIRES_FACTORY: `Vector index "%s" was serialized as IVF. Import ivf from "zbsearch/trees/vector-ivf" and pass indexes.%s at create().`,
-  RESERVED_SCHEMA_PROPERTY: `"%s" is a reserved property name and cannot be used in the schema.`
+  RESERVED_SCHEMA_PROPERTY: `"%s" is a reserved property name and cannot be used in the schema.`,
+  SUGGEST_NOT_SUPPORTED: `The configured index component does not support "suggest", as it cannot expand a query token into the indexed words it matches.`
 }
 
 export type ErrorCode = keyof typeof errors

--- a/packages/zbsearch/src/index.ts
+++ b/packages/zbsearch/src/index.ts
@@ -6,6 +6,7 @@ export { remove, removeMultiple } from './methods/remove.js'
 export { search } from './methods/search.js'
 export { searchVector } from './methods/search-vector.js'
 export { load, save } from './methods/serialization.js'
+export { autoSuggest, suggest } from './methods/suggest.js'
 export { update, updateMultiple } from './methods/update.js'
 export { upsert, upsertMultiple } from './methods/upsert.js'
 

--- a/packages/zbsearch/src/methods/search-fulltext.ts
+++ b/packages/zbsearch/src/methods/search-fulltext.ts
@@ -20,19 +20,9 @@ import { getNanosecondsTime, removeVectorsFromHits, sortTokenScorePredicate } fr
 import { count } from './docs.js'
 import { fetchDocuments, fetchDocumentsWithDistinct } from './fetch-documents.js'
 
-export function innerFullTextSearch<T extends AnyZBSearch>(
-  zbsearch: T,
-  params: Pick<
-    SearchParamsFullText<T>,
-    'term' | 'properties' | 'where' | 'exact' | 'prefix' | 'tolerance' | 'boost' | 'relevance' | 'threshold'
-  >,
-  language: Language | undefined,
-  precomputedWhereFiltersIDs?: Set<number>
-) {
-  const { term, properties } = params
-
+export function getPropertiesToSearch<T extends AnyZBSearch>(zbsearch: T, properties: '*' | unknown[] | undefined) {
   const index = zbsearch.data.index
-  // Get searchable string properties
+
   let propertiesToSearch = zbsearch.caches['propertiesToSearch'] as string[]
   if (!propertiesToSearch) {
     const propertiesToSearchWithTypes = zbsearch.index.getSearchablePropertiesWithTypes(index)
@@ -54,6 +44,23 @@ export function innerFullTextSearch<T extends AnyZBSearch>(
 
     propertiesToSearch = propertiesToSearch.filter((prop: string) => (properties as string[]).includes(prop))
   }
+
+  return propertiesToSearch
+}
+
+export function innerFullTextSearch<T extends AnyZBSearch>(
+  zbsearch: T,
+  params: Pick<
+    SearchParamsFullText<T>,
+    'term' | 'properties' | 'where' | 'exact' | 'prefix' | 'tolerance' | 'boost' | 'relevance' | 'threshold'
+  >,
+  language: Language | undefined,
+  precomputedWhereFiltersIDs?: Set<number>
+) {
+  const { term, properties } = params
+
+  const index = zbsearch.data.index
+  const propertiesToSearch = getPropertiesToSearch(zbsearch, properties)
 
   // If filters are enabled, we need to get the IDs of the documents that match the filters.
   const hasFilters = Object.keys(params.where ?? {}).length > 0
@@ -254,7 +261,7 @@ export const defaultBM25Params: BM25Params = {
   b: 0.75,
   d: 0.5
 }
-function applyDefault(bm25Relevance?: BM25Params): Required<BM25Params> {
+export function applyDefault(bm25Relevance?: BM25Params): Required<BM25Params> {
   const r = bm25Relevance ?? {}
   r.k = r.k ?? defaultBM25Params.k
   r.b = r.b ?? defaultBM25Params.b

--- a/packages/zbsearch/src/methods/suggest.ts
+++ b/packages/zbsearch/src/methods/suggest.ts
@@ -1,0 +1,176 @@
+import { InternalDocumentID } from '../components/internal-document-id-store.js'
+import { createError } from '../errors.js'
+import type {
+  AnyZBSearch,
+  ElapsedTime,
+  Suggestion,
+  SuggestionDocumentMatch,
+  SuggestionQueryToken,
+  SuggestParams,
+  SuggestResults
+} from '../types.js'
+import { getNanosecondsTime } from '../utils.js'
+import { count } from './docs.js'
+import { applyDefault, getPropertiesToSearch } from './search-fulltext.js'
+
+/**
+ * Returns the ranked query completions for a partially typed term, to build an autocomplete
+ * dropdown without having to dedupe and rank the terms of full search results.
+ *
+ * Suggestions are indexed words, so they go through the same text analysis as the documents:
+ * with a stemmer configured, the suggested words are stems.
+ *
+ * @example
+ * const result = suggest(db, { term: 'noise can' })
+ *
+ * // {
+ * //   elapsed: { raw: 181208, formatted: '181μs' },
+ * //   count: 2,
+ * //   suggestions: [
+ * //     { suggestion: 'noise cancelling', terms: ['noise', 'cancelling'], score: 4.2, count: 3 },
+ * //     { suggestion: 'noise cancellation', terms: ['noise', 'cancellation'], score: 1.1, count: 1 }
+ * //   ]
+ * // }
+ */
+export function suggest<T extends AnyZBSearch>(
+  zbsearch: T,
+  params: SuggestParams<T>,
+  language?: string
+): SuggestResults {
+  const timeStart = getNanosecondsTime()
+
+  const { term, limit = 10, offset = 0, threshold = 0, prefix = true, tolerance = 0 } = params
+
+  const searchSuggestions = zbsearch.index.searchSuggestions
+
+  if (typeof searchSuggestions !== 'function') {
+    throw createError('SUGGEST_NOT_SUPPORTED')
+  }
+
+  const index = zbsearch.data.index
+  const propertiesToSearch = getPropertiesToSearch(zbsearch, params.properties)
+  const tokens = zbsearch.tokenizer.tokenize(term ?? '', language)
+
+  if (!tokens.length || !propertiesToSearch.length) {
+    return emptyResults(zbsearch, timeStart)
+  }
+
+  const lastToken = tokens.length - 1
+  const queryTokens: SuggestionQueryToken[] = tokens.map((token, i) => ({
+    token,
+    exact: !tolerance && (prefix === false || (prefix === 'last' && i < lastToken)),
+    tolerance,
+    completion: i === lastToken
+  }))
+
+  const hasFilters = Object.keys(params.where ?? {}).length > 0
+  const whereFiltersIDs = hasFilters
+    ? zbsearch.index.searchByWhereClause(index, zbsearch.tokenizer, params.where!, language)
+    : undefined
+
+  if (hasFilters && !whereFiltersIDs!.size) {
+    return emptyResults(zbsearch, timeStart)
+  }
+
+  const matches = searchSuggestions(
+    index,
+    queryTokens,
+    propertiesToSearch,
+    params.boost ?? {},
+    applyDefault(params.relevance),
+    count(zbsearch),
+    whereFiltersIDs
+  )
+
+  const suggestions = aggregateSuggestions(matches, tokens, threshold)
+
+  return {
+    elapsed: zbsearch.formatElapsedTime(getNanosecondsTime() - timeStart) as ElapsedTime,
+    count: suggestions.length,
+    suggestions: suggestions.slice(offset, offset + limit)
+  }
+}
+
+/**
+ * Alias of {@link suggest}, for familiarity with other search engines.
+ */
+export const autoSuggest = suggest
+
+function emptyResults<T extends AnyZBSearch>(zbsearch: T, timeStart: bigint): SuggestResults {
+  return {
+    elapsed: zbsearch.formatElapsedTime(getNanosecondsTime() - timeStart) as ElapsedTime,
+    count: 0,
+    suggestions: []
+  }
+}
+
+function aggregateSuggestions(
+  matches: Map<InternalDocumentID, SuggestionDocumentMatch>,
+  tokens: string[],
+  threshold: number
+): Suggestion[] {
+  const suggestions = new Map<string, Suggestion>()
+  const partialMatches: SuggestionDocumentMatch[] = []
+
+  for (const match of matches.values()) {
+    if (match.matchedTokens < tokens.length) {
+      if (threshold > 0) {
+        partialMatches.push(match)
+      }
+      continue
+    }
+
+    addSuggestions(suggestions, match, tokens)
+  }
+
+  if (partialMatches.length > 0) {
+    partialMatches.sort((a, b) => b.score - a.score)
+    const partialsToKeep = Math.ceil(partialMatches.length * Math.min(threshold, 1))
+
+    for (let i = 0; i < partialsToKeep; i++) {
+      addSuggestions(suggestions, partialMatches[i], tokens)
+    }
+  }
+
+  return Array.from(suggestions.values()).sort(
+    (a, b) => b.score - a.score || b.count - a.count || (a.suggestion < b.suggestion ? -1 : 1)
+  )
+}
+
+function addSuggestions(
+  suggestions: Map<string, Suggestion>,
+  match: SuggestionDocumentMatch,
+  tokens: string[]
+): void {
+  const completionIndex = tokens.length - 1
+  const context = match.words.map((word, i) => word ?? tokens[i])
+  let contextScore = 0
+
+  for (let i = 0; i < completionIndex; i++) {
+    contextScore += match.wordScores[i]
+  }
+
+  if (!match.completions?.size) {
+    addSuggestion(suggestions, context, contextScore + match.wordScores[completionIndex])
+    return
+  }
+
+  for (const [word, score] of match.completions) {
+    const terms = context.slice()
+    terms[completionIndex] = word
+    addSuggestion(suggestions, terms, contextScore + score)
+  }
+}
+
+function addSuggestion(suggestions: Map<string, Suggestion>, terms: string[], score: number): void {
+  const phrase = terms.join(' ')
+  const existing = suggestions.get(phrase)
+
+  if (existing) {
+    existing.score += score
+    existing.count++
+    return
+  }
+
+  suggestions.set(phrase, { suggestion: phrase, terms, score, count: 1 })
+}

--- a/packages/zbsearch/src/methods/suggest.ts
+++ b/packages/zbsearch/src/methods/suggest.ts
@@ -1,3 +1,4 @@
+import { searchSuggestions as defaultSearchSuggestions } from '../components/index.js'
 import { InternalDocumentID } from '../components/internal-document-id-store.js'
 import { createError } from '../errors.js'
 import type {
@@ -41,7 +42,11 @@ export function suggest<T extends AnyZBSearch>(
 
   const { term, limit = 10, offset = 0, threshold = 0, prefix = true, tolerance = 0 } = params
 
-  const searchSuggestions = zbsearch.index.searchSuggestions
+  const searchSuggestions =
+    zbsearch.index.searchSuggestions ??
+    (zbsearch.index.supportsSuggestions
+      ? (defaultSearchSuggestions as unknown as NonNullable<T['index']['searchSuggestions']>)
+      : undefined)
 
   if (typeof searchSuggestions !== 'function') {
     throw createError('SUGGEST_NOT_SUPPORTED')
@@ -58,7 +63,7 @@ export function suggest<T extends AnyZBSearch>(
   const lastToken = tokens.length - 1
   const queryTokens: SuggestionQueryToken[] = tokens.map((token, i) => ({
     token,
-    exact: !tolerance && (prefix === false || (prefix === 'last' && i < lastToken)),
+    exact: prefix === false || (prefix === 'last' && i < lastToken),
     tolerance,
     completion: i === lastToken
   }))

--- a/packages/zbsearch/src/types.ts
+++ b/packages/zbsearch/src/types.ts
@@ -934,7 +934,10 @@ export type SuggestionDocumentMatch = {
   matchedTokens: number
 
   /**
-   * The relevance of the document for the whole query.
+   * The relevance of the document for the whole query, summing the contribution of every
+   * word it matched. This is the same score `search` gives the document, so it ranks the
+   * partially matching documents consistently with it — unlike `wordScores`, which only
+   * keeps the best word per token to build the suggested phrase.
    */
   score: number
 

--- a/packages/zbsearch/src/types.ts
+++ b/packages/zbsearch/src/types.ts
@@ -771,6 +771,180 @@ export type SearchParams<T extends AnyZBSearch, ResultDocument = TypedDocument<T
   | SearchParamsHybrid<T, ResultDocument>
   | SearchParamsVector<T, ResultDocument>
 
+export interface SuggestParams<T extends AnyZBSearch> {
+  /**
+   * The partial term to complete. It can contain multiple words: every word is
+   * expanded and the suggestion is the completion of the whole phrase.
+   */
+  term: string
+
+  /**
+   * The properties of the document to take the suggestions from.
+   */
+  properties?: '*' | FlattenSchemaProperty<T>[]
+
+  /**
+   * The number of suggestions to return. Defaults to 10.
+   */
+  limit?: number
+
+  /**
+   * The number of suggestions to skip. Defaults to 0.
+   */
+  offset?: number
+
+  /**
+   * Which query words are prefix-expanded (search-as-you-type).
+   *
+   * - `true` (default): every word is expanded, so "noi can" suggests "noise cancelling".
+   * - `'last'`: only the last word is expanded, the previous ones must match a whole
+   *   indexed word. This is the cheapest option and the most accurate one when the user
+   *   is typing left to right.
+   * - `false`: no expansion, only whole indexed words are matched. Useful with `tolerance`
+   *   to suggest corrections of a fully typed query.
+   */
+  prefix?: boolean | 'last'
+
+  /**
+   * The maximum [levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)
+   * between each query word and the suggested word, to tolerate typos.
+   */
+  tolerance?: number
+
+  /**
+   * The BM25 parameters used to score the documents the suggestions are aggregated from.
+   *
+   * @see https://en.wikipedia.org/wiki/Okapi_BM25
+   */
+  relevance?: BM25Params
+
+  /**
+   * The boost to apply to the properties, exactly as in `search`.
+   *
+   * @example
+   * // Suggest completions found in the title before the ones found in the description.
+   * const result = suggest(db, {
+   *  term: 'head',
+   *  boost: {
+   *   title: 2
+   *  }
+   * })
+   */
+  boost?: Partial<Record<OnlyStrings<FlattenSchemaProperty<T>[]>, number>>
+
+  /**
+   * Only aggregate suggestions from the documents matching the filters.
+   *
+   * @example
+   * const result = suggest(db, {
+   *  term: 'head',
+   *  where: {
+   *    price: {
+   *      lt: 100
+   *    }
+   *  }
+   * })
+   */
+  where?: Partial<WhereCondition<T['schema']>>
+
+  /**
+   * How many of the query words a document must match to contribute a suggestion.
+   *
+   * With the default `0`, only the documents matching every word are considered.
+   * With `1`, all the partially matching documents are considered as well. Any value
+   * in between includes that percentage of the partially matching documents, ordered
+   * by relevance. Words with no match are kept verbatim in the returned suggestion.
+   */
+  threshold?: number
+}
+
+export type Suggestion = {
+  /**
+   * The suggested completion of the searched term.
+   */
+  suggestion: string
+
+  /**
+   * The indexed words the suggestion is made of, one per word of the searched term.
+   */
+  terms: string[]
+
+  /**
+   * The aggregated relevance of the documents this suggestion was found in.
+   * Suggestions are returned sorted by this value, in descending order.
+   */
+  score: number
+
+  /**
+   * How many documents this suggestion was found in.
+   */
+  count: number
+}
+
+export type SuggestResults = {
+  /**
+   * The number of all the suggestions found, ignoring `limit` and `offset`.
+   */
+  count: number
+
+  /**
+   * The suggestions, sorted by descending score, taking `limit` and `offset` into account.
+   */
+  suggestions: Suggestion[]
+
+  /**
+   * The time taken to compute the suggestions.
+   */
+  elapsed: ElapsedTime
+}
+
+/**
+ * A single word of a suggest query, with the matching strategy to use for it.
+ */
+export type SuggestionQueryToken = {
+  token: string
+  exact: boolean
+  tolerance: number
+
+  /**
+   * Whether this is the word being completed, so that every word matching it is a
+   * candidate suggestion. The other tokens are the context of the completion.
+   */
+  completion?: boolean
+}
+
+/**
+ * How a single document matches a suggest query.
+ */
+export type SuggestionDocumentMatch = {
+  /**
+   * The best matching indexed word for each query token, `undefined` when the
+   * token has no match in this document.
+   */
+  words: (string | undefined)[]
+
+  /**
+   * The score of each entry of `words`.
+   */
+  wordScores: number[]
+
+  /**
+   * How many query tokens this document matches.
+   */
+  matchedTokens: number
+
+  /**
+   * The relevance of the document for the whole query.
+   */
+  score: number
+
+  /**
+   * Every word of this document matching the completion token, with its score. Absent when
+   * the document does not match the completion token, or when no token was flagged as such.
+   */
+  completions?: Map<string, number>
+}
+
 export type Result<Document> = {
   /**
    * The id of the document.
@@ -1025,6 +1199,21 @@ export interface IIndex<I extends AnyIndexStore> {
     threshold?: number,
     prefix?: boolean
   ): TokenScore[]
+
+  /**
+   * Collects, for every document matching the given query tokens, the indexed words
+   * that matched and their relevance. Optional: index implementations that cannot
+   * expand a token into the indexed words it matches don't support `suggest`.
+   */
+  searchSuggestions?<T extends AnyZBSearch>(
+    index: AnyIndexStore,
+    queryTokens: SuggestionQueryToken[],
+    propertiesToSearch: string[],
+    boost: Partial<Record<OnlyStrings<FlattenSchemaProperty<T>[]>, number>>,
+    relevance: Required<BM25Params>,
+    docsCount: number,
+    whereFiltersIDs: Set<InternalDocumentID> | undefined
+  ): Map<InternalDocumentID, SuggestionDocumentMatch>
 
   searchByWhereClause<T extends AnyZBSearch>(
     index: AnyIndexStore,

--- a/packages/zbsearch/src/types.ts
+++ b/packages/zbsearch/src/types.ts
@@ -903,7 +903,14 @@ export type SuggestResults = {
  */
 export type SuggestionQueryToken = {
   token: string
+
+  /**
+   * Whether to only match whole indexed words, with no prefix expansion. It composes with
+   * `tolerance`: a whole word within the tolerated edit distance still matches, so a word
+   * that merely starts with the token is not accepted just because a tolerance was set.
+   */
   exact: boolean
+
   tolerance: number
 
   /**
@@ -1204,9 +1211,17 @@ export interface IIndex<I extends AnyIndexStore> {
   ): TokenScore[]
 
   /**
+   * Whether this index can expand a query token into the indexed words it matches, which is
+   * what `suggest` is built on. The default index component declares it and lets `suggest`
+   * use its own implementation, so that bundles which never import `suggest` don't carry it.
+   * Implementations that need a different expansion provide `searchSuggestions` instead.
+   */
+  supportsSuggestions?: boolean
+
+  /**
    * Collects, for every document matching the given query tokens, the indexed words
-   * that matched and their relevance. Optional: index implementations that cannot
-   * expand a token into the indexed words it matches don't support `suggest`.
+   * that matched and their relevance. Overrides the default implementation used when
+   * `supportsSuggestions` is set; an index that declares neither doesn't support `suggest`.
    */
   searchSuggestions?<T extends AnyZBSearch>(
     index: AnyIndexStore,

--- a/packages/zbsearch/tests/suggest.test.ts
+++ b/packages/zbsearch/tests/suggest.test.ts
@@ -126,6 +126,37 @@ t.test('suggest method', (t) => {
     t.end()
   })
 
+  t.test('should keep the context words whole when a tolerance is combined with prefix', (t) => {
+    const db = create({ schema: { title: 'string' } as const })
+
+    insertMultiple(db, [{ title: 'cancel policy' }, { title: 'cancellation policy' }])
+
+    t.strictSame(
+      suggest(db, { term: 'cancel poli', prefix: 'last', tolerance: 1 }).suggestions.map(
+        ({ suggestion }) => suggestion
+      ),
+      ['cancel policy'],
+      'a tolerance must not turn a context word into a prefix expansion'
+    )
+    t.strictSame(
+      suggest(db, { term: 'cancel poli', prefix: 'last' }).suggestions.map(({ suggestion }) => suggestion),
+      ['cancel policy'],
+      'same suggestions as without the tolerance'
+    )
+    t.strictSame(
+      suggest(db, { term: 'cancel poli', prefix: true, tolerance: 1 }).suggestions.map(({ suggestion }) => suggestion),
+      ['cancel policy', 'cancellation policy'],
+      'prefix true still expands the context words'
+    )
+    t.strictSame(
+      suggest(db, { term: 'cancl poli', prefix: 'last', tolerance: 1 }).suggestions.map(({ suggestion }) => suggestion),
+      ['cancel policy'],
+      'a whole context word within the tolerated distance still matches'
+    )
+
+    t.end()
+  })
+
   t.test('should only take the suggestions from the given properties', (t) => {
     const db = createProductsDB()
 
@@ -301,8 +332,7 @@ t.test('suggest method', (t) => {
   })
 
   t.test('should throw when the index component cannot expand a token', (t) => {
-    const index = { ...defaultIndex.createIndex() }
-    delete index.searchSuggestions
+    const { supportsSuggestions, ...index } = defaultIndex.createIndex()
 
     const db = create({
       schema: { title: 'string' } as const,
@@ -311,7 +341,35 @@ t.test('suggest method', (t) => {
 
     insertMultiple(db, [{ title: 'Noise cancelling headphones' }])
 
+    t.notOk(index.searchSuggestions, 'the default component declares the capability instead of the implementation')
     t.throws(() => suggest(db, { term: 'head' }), { code: 'SUGGEST_NOT_SUPPORTED' })
+
+    t.end()
+  })
+
+  t.test('should let an index component provide its own expansion', (t) => {
+    let calls = 0
+    const index = {
+      ...defaultIndex.createIndex(),
+      searchSuggestions() {
+        calls++
+        return new Map([[1, { words: ['custom'], wordScores: [3], matchedTokens: 1, score: 3 }]])
+      }
+    }
+
+    const db = create({
+      schema: { title: 'string' } as const,
+      components: { index }
+    })
+
+    insertMultiple(db, [{ title: 'Noise cancelling headphones' }])
+
+    t.strictSame(
+      suggest(db, { term: 'head' }).suggestions,
+      [{ suggestion: 'custom', terms: ['custom'], score: 3, count: 1 }],
+      'the component implementation wins over the default one'
+    )
+    t.equal(calls, 1)
 
     t.end()
   })

--- a/packages/zbsearch/tests/suggest.test.ts
+++ b/packages/zbsearch/tests/suggest.test.ts
@@ -1,0 +1,320 @@
+import t from 'tap'
+import { index as defaultIndex } from '../src/components.js'
+import { autoSuggest, count, create, insertMultiple, suggest } from '../src/index.js'
+
+function createProductsDB() {
+  const db = create({
+    schema: {
+      title: 'string',
+      description: 'string',
+      price: 'number'
+    } as const
+  })
+
+  insertMultiple(db, [
+    { title: 'Noise cancelling headphones', description: 'Wireless over-ear headphones', price: 299 },
+    { title: 'Noise cancelling earbuds', description: 'In-ear active noise cancellation', price: 199 },
+    { title: 'Wired headphones', description: 'Cheap headphones for the office', price: 30 },
+    { title: 'Noisy blue t-shirt', description: 'A very loud shirt', price: 20 }
+  ])
+
+  return db
+}
+
+t.test('suggest method', (t) => {
+  t.test('should complete a single word and report the elapsed time', (t) => {
+    const db = createProductsDB()
+    const result = suggest(db, { term: 'head' })
+
+    t.equal(result.count, 1)
+    t.strictSame(
+      result.suggestions.map(({ suggestion, terms, count }) => ({ suggestion, terms, count })),
+      [{ suggestion: 'headphones', terms: ['headphones'], count: 2 }]
+    )
+    t.ok(result.suggestions[0].score > 0)
+    t.ok(result.elapsed.raw > 0)
+    t.ok(result.elapsed.formatted)
+
+    t.end()
+  })
+
+  t.test('should rank the suggestions by aggregated document relevance', (t) => {
+    const db = createProductsDB()
+    const result = suggest(db, { term: 'noi' })
+
+    t.strictSame(
+      result.suggestions.map(({ suggestion }) => suggestion),
+      ['noise', 'noisy']
+    )
+    t.ok(result.suggestions[0].score > result.suggestions[1].score)
+    t.equal(result.suggestions[0].count, 2)
+    t.equal(result.suggestions[1].count, 1)
+
+    t.end()
+  })
+
+  t.test('should complete the last word of a phrase, keeping the previous ones', (t) => {
+    const db = createProductsDB()
+    const result = suggest(db, { term: 'noise can' })
+
+    t.strictSame(
+      result.suggestions.map(({ suggestion, count }) => ({ suggestion, count })),
+      [
+        { suggestion: 'noise cancelling', count: 2 },
+        { suggestion: 'noise cancellation', count: 1 }
+      ]
+    )
+
+    t.end()
+  })
+
+  t.test('should not suggest words that never appear together in a document', (t) => {
+    const db = createProductsDB()
+    const result = suggest(db, { term: 'noi shirt' })
+
+    // "noisy" and "shirt" share a document, "noise" and "shirt" do not.
+    t.strictSame(
+      result.suggestions.map(({ suggestion }) => suggestion),
+      ['noisy shirt']
+    )
+
+    t.end()
+  })
+
+  t.test('should expand only the last word when prefix is "last"', (t) => {
+    const db = createProductsDB()
+
+    t.strictSame(
+      suggest(db, { term: 'noi cancelling', prefix: 'last' }).suggestions,
+      [],
+      'the previous words must match a whole indexed word'
+    )
+    t.strictSame(
+      suggest(db, { term: 'noise can', prefix: 'last' }).suggestions.map(({ suggestion }) => suggestion),
+      ['noise cancelling', 'noise cancellation']
+    )
+
+    t.end()
+  })
+
+  t.test('should only match whole indexed words when prefix is false', (t) => {
+    const db = createProductsDB()
+
+    t.strictSame(suggest(db, { term: 'head', prefix: false }).suggestions, [])
+    t.strictSame(
+      suggest(db, { term: 'headphones', prefix: false }).suggestions.map(({ suggestion }) => suggestion),
+      ['headphones']
+    )
+
+    t.end()
+  })
+
+  t.test('should tolerate typos', (t) => {
+    const db = createProductsDB()
+
+    t.strictSame(suggest(db, { term: 'hedphones' }).suggestions, [], 'no tolerance, no suggestion')
+    t.strictSame(
+      suggest(db, { term: 'hedphones', tolerance: 1 }).suggestions.map(({ suggestion }) => suggestion),
+      ['headphones']
+    )
+    t.strictSame(
+      suggest(db, { term: 'hedphones', tolerance: 1, prefix: false }).suggestions.map(({ suggestion }) => suggestion),
+      ['headphones'],
+      'tolerance applies to fully typed words too'
+    )
+
+    t.end()
+  })
+
+  t.test('should only take the suggestions from the given properties', (t) => {
+    const db = createProductsDB()
+
+    t.strictSame(
+      suggest(db, { term: 'wire', properties: ['title'] }).suggestions.map(({ suggestion }) => suggestion),
+      ['wired']
+    )
+    t.strictSame(
+      suggest(db, { term: 'wire', properties: ['description'] }).suggestions.map(({ suggestion }) => suggestion),
+      ['wireless']
+    )
+
+    const both = suggest(db, { term: 'wire' })
+    t.equal(both.count, 2)
+
+    t.end()
+  })
+
+  t.test('should throw on unknown properties', (t) => {
+    const db = createProductsDB()
+
+    t.throws(() => suggest(db, { term: 'head', properties: ['unknown'] as never[] }), {
+      code: 'UNKNOWN_INDEX'
+    })
+
+    t.end()
+  })
+
+  t.test('should boost the properties', (t) => {
+    const db = createProductsDB()
+
+    const unboosted = suggest(db, { term: 'wire' })
+    const boosted = suggest(db, { term: 'wire', boost: { description: 5 } })
+
+    t.strictSame(
+      unboosted.suggestions.map(({ suggestion }) => suggestion),
+      ['wired', 'wireless']
+    )
+    t.strictSame(
+      boosted.suggestions.map(({ suggestion }) => suggestion),
+      ['wireless', 'wired'],
+      'boosting the description promotes the word found in it'
+    )
+
+    t.end()
+  })
+
+  t.test('should only aggregate the documents matching the filters', (t) => {
+    const db = createProductsDB()
+    const result = suggest(db, { term: 'head', where: { price: { lt: 100 } } })
+
+    t.strictSame(
+      result.suggestions.map(({ suggestion, count }) => ({ suggestion, count })),
+      [{ suggestion: 'headphones', count: 1 }]
+    )
+
+    t.strictSame(suggest(db, { term: 'head', where: { price: { lt: 10 } } }).suggestions, [])
+
+    t.end()
+  })
+
+  t.test('should ignore partially matching documents unless a threshold is given', (t) => {
+    const db = createProductsDB()
+
+    t.strictSame(suggest(db, { term: 'noise shir' }).suggestions, [])
+
+    const withThreshold = suggest(db, { term: 'noise shir', threshold: 1 })
+    t.strictSame(
+      withThreshold.suggestions.map(({ suggestion, terms }) => ({ suggestion, terms })).sort(),
+      [
+        // The documents matching "noise" only keep the unmatched word verbatim, the one matching "shir" only completes it.
+        { suggestion: 'noise shir', terms: ['noise', 'shir'] },
+        { suggestion: 'noise shirt', terms: ['noise', 'shirt'] }
+      ].sort(),
+      'the words with no match are kept verbatim'
+    )
+
+    t.end()
+  })
+
+  t.test('should paginate the suggestions', (t) => {
+    const db = createProductsDB()
+
+    const all = suggest(db, { term: 'noi' })
+    t.equal(all.count, 2)
+    t.equal(all.suggestions.length, 2)
+
+    const first = suggest(db, { term: 'noi', limit: 1 })
+    t.equal(first.count, 2, 'count ignores limit and offset')
+    t.strictSame(
+      first.suggestions.map(({ suggestion }) => suggestion),
+      ['noise']
+    )
+
+    const second = suggest(db, { term: 'noi', limit: 1, offset: 1 })
+    t.strictSame(
+      second.suggestions.map(({ suggestion }) => suggestion),
+      ['noisy']
+    )
+
+    t.strictSame(suggest(db, { term: 'noi', offset: 2 }).suggestions, [])
+
+    t.end()
+  })
+
+  t.test('should return no suggestion for an empty or unknown term', (t) => {
+    const db = createProductsDB()
+
+    for (const term of ['', '   ', 'zzz']) {
+      const result = suggest(db, { term })
+      t.equal(result.count, 0, `no suggestion for "${term}"`)
+      t.strictSame(result.suggestions, [])
+      t.ok(result.elapsed.formatted)
+    }
+
+    t.end()
+  })
+
+  t.test('should be exposed as autoSuggest too', (t) => {
+    const db = createProductsDB()
+
+    t.strictSame(autoSuggest(db, { term: 'head' }).suggestions, suggest(db, { term: 'head' }).suggestions)
+
+    t.end()
+  })
+
+  t.test('should score the documents exactly as search does', (t) => {
+    const db = create({ schema: { title: 'string', description: 'string' } as const })
+
+    insertMultiple(db, [
+      { title: 'cancel cancelling cancellation cancelled', description: 'cancel policy' },
+      { title: 'noise cancelling headphones', description: 'wireless' },
+      { title: 'unrelated', description: 'nothing here' }
+    ])
+
+    const relevance = { k: 1.2, b: 0.75, d: 0.5 }
+    const properties = ['title', 'description']
+    const docsCount = count(db)
+
+    const searchScores = defaultIndex.search(
+      db.data.index,
+      'can',
+      db.tokenizer,
+      undefined,
+      properties,
+      false,
+      0,
+      {},
+      relevance,
+      docsCount,
+      undefined,
+      1,
+      true
+    )
+
+    const matches = defaultIndex.searchSuggestions(
+      db.data.index,
+      [{ token: 'can', exact: false, tolerance: 0, completion: true }],
+      properties,
+      {},
+      relevance,
+      docsCount,
+      undefined
+    )
+
+    t.strictSame(
+      searchScores.map(([id, score]) => [id, score]).sort(),
+      Array.from(matches, ([id, match]) => [id, match.score]).sort(),
+      'every expansion of a token contributes to the document score, as in search'
+    )
+
+    t.end()
+  })
+
+  t.test('should throw when the index component cannot expand a token', (t) => {
+    const index = { ...defaultIndex.createIndex() }
+    delete index.searchSuggestions
+
+    const db = create({
+      schema: { title: 'string' } as const,
+      components: { index }
+    })
+
+    insertMultiple(db, [{ title: 'Noise cancelling headphones' }])
+
+    t.throws(() => suggest(db, { term: 'head' }), { code: 'SUGGEST_NOT_SUPPORTED' })
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/packages/zbsearch/tests/type/suggest.test-d.ts
+++ b/packages/zbsearch/tests/type/suggest.test-d.ts
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd'
+import { suggest } from '../../src/index.js'
+import type { SuggestParams, SuggestResults, ZBSearch } from '../../src/types.d.ts'
+
+const movieSchema = {
+  title: 'string',
+  year: 'number',
+  actors: 'string[]',
+  isFavorite: 'boolean',
+  stars: 'enum',
+  meta: {
+    foo: 'string'
+  }
+} as const
+
+type MovieDB = ZBSearch<typeof movieSchema>
+
+// Test suggest properties type
+{
+  type MovieSuggestParamsProperties = SuggestParams<MovieDB>['properties']
+
+  expectAssignable<MovieSuggestParamsProperties>('*')
+  expectAssignable<MovieSuggestParamsProperties>(['title'])
+  expectAssignable<MovieSuggestParamsProperties>(['meta.foo'])
+  expectNotAssignable<MovieSuggestParamsProperties>(['meta.unknown'])
+  expectNotAssignable<MovieSuggestParamsProperties>(['unknown'])
+}
+
+// Test suggest boost type
+{
+  type MovieSuggestParamsBoost = SuggestParams<MovieDB>['boost']
+
+  expectAssignable<MovieSuggestParamsBoost>(undefined)
+  expectAssignable<MovieSuggestParamsBoost>({ title: 1 })
+  expectAssignable<MovieSuggestParamsBoost>({ 'meta.foo': 1 })
+  expectNotAssignable<MovieSuggestParamsBoost>({ unknown: 1 })
+}
+
+// Test suggest prefix type
+{
+  type MovieSuggestParamsPrefix = SuggestParams<MovieDB>['prefix']
+
+  expectAssignable<MovieSuggestParamsPrefix>(true)
+  expectAssignable<MovieSuggestParamsPrefix>(false)
+  expectAssignable<MovieSuggestParamsPrefix>('last')
+  expectNotAssignable<MovieSuggestParamsPrefix>('first')
+}
+
+// Test suggest where type
+{
+  type MovieSuggestParamsWhere = SuggestParams<MovieDB>['where']
+
+  expectAssignable<MovieSuggestParamsWhere>({ year: { gt: 2000 } })
+  expectAssignable<MovieSuggestParamsWhere>({ isFavorite: true })
+  expectNotAssignable<MovieSuggestParamsWhere>({ unknown: true })
+}
+
+// Test suggest results
+{
+  const db = null as unknown as MovieDB
+  const results = suggest(db, { term: 'the god' })
+
+  expectType<SuggestResults>(results)
+  expectType<number>(results.count)
+  expectType<string>(results.suggestions[0].suggestion)
+  expectType<string[]>(results.suggestions[0].terms)
+  expectType<number>(results.suggestions[0].score)
+  expectType<number>(results.suggestions[0].count)
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New public API on the core index/search stack with scoring that must stay aligned with `search`; custom index plugins without `searchSuggestions` will error at runtime.
> 
> **Overview**
> Adds **`suggest`** (alias **`autoSuggest`**) so autocomplete UIs get **ranked query completions** from indexed words instead of deduping `search` hits. Completions respect multi-word context (words must co-occur in a document), **`prefix`** (`true` / `'last'` / `false`), typo **`tolerance`**, **`where`**, **`boost`**, **`relevance`**, **`threshold`**, and **`limit`/`offset`**.
> 
> The default radix index implements **`searchSuggestions`**, scoring documents with the same BM25 + prefix-expansion demotion as full-text **`search`**, then aggregating completion phrases by score and document count. Custom index components without token expansion fail with **`SUGGEST_NOT_SUPPORTED`**.
> 
> **`getPropertiesToSearch`** and **`applyDefault`** are shared from full-text search for suggest. Docs and README highlight autocomplete; tests cover behavior and TypeScript types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216df4bb57fa59d71bf051e1429c7b5ae925bbee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->