### PR TITLE
Fix PluginPT15 do not handling accuentuate search

### DIFF
--- a/packages/plugin-pt15/test/index.test.ts
+++ b/packages/plugin-pt15/test/index.test.ts
@@ -130,3 +130,28 @@ t.test('where string', async (t) => {
     'String filters are not supported'
   )
 })
+
+// https://github.com/oramasearch/orama/issues/995
+t.test('matches accented content when the query is typed without accents', async (t) => {
+  const db = create({
+    schema: { title: 'string' } as const,
+    plugins: [pluginPT15()]
+  })
+
+  await insertMultiple(db, [
+    { id: '1', title: 'Invitation gâteau au chocolat' },
+    { id: '2', title: 'Crème brûlée recipe' }
+  ])
+
+  for (const term of ['Gateau', 'Gâteau', 'gateau au chocolat']) {
+    const result = search(db, { term })
+    t.equal(result.count, 1, `"${term}" finds the gâteau document`)
+    t.equal(result.hits[0].id, '1')
+  }
+
+  for (const term of ['creme brulee', 'Crème brûlée']) {
+    const result = search(db, { term })
+    t.equal(result.count, 1, `"${term}" finds the crème brûlée document`)
+    t.equal(result.hits[0].id, '2')
+  }
+})

--- a/packages/plugin-qps/test/index.test.ts
+++ b/packages/plugin-qps/test/index.test.ts
@@ -152,3 +152,28 @@ t.test('string[] is allowed by this plugin', { only: true }, async (t) => {
 
   t.equal(found.count, found2.count)
 })
+
+// https://github.com/oramasearch/orama/issues/995
+t.test('matches accented content when the query is typed without accents', async (t) => {
+  const db = create({
+    schema: { title: 'string' } as const,
+    plugins: [pluginQPS()]
+  })
+
+  await insertMultiple(db, [
+    { id: '1', title: 'Invitation gâteau au chocolat' },
+    { id: '2', title: 'Crème brûlée recipe' }
+  ])
+
+  for (const term of ['Gateau', 'Gâteau', 'gateau au chocolat']) {
+    const result = await search(db, { term })
+    t.equal(result.count, 1, `"${term}" finds the gâteau document`)
+    t.equal(result.hits[0].id, '1')
+  }
+
+  for (const term of ['creme brulee', 'Crème brûlée']) {
+    const result = await search(db, { term })
+    t.equal(result.count, 1, `"${term}" finds the crème brûlée document`)
+    t.equal(result.hits[0].id, '2')
+  }
+})

--- a/packages/zbsearch/src/components/tokenizer/index.ts
+++ b/packages/zbsearch/src/components/tokenizer/index.ts
@@ -31,17 +31,17 @@ export function normalizeToken(this: DefaultTokenizer, prop: string, token: stri
     return this.normalizationCache.get(key)!
   }
 
+  // Fold diacritics BEFORE stopword lookup and stemming, so that accented and unaccented surface forms of the same word converge (e.g. Portuguese "pão"/"pao" must neither stem differently nor be treated as a stopword only in one of its two spellings, depending on how the user typed it). `stopWordsSet` is folded to match, see `createTokenizer`.
+  if (!LANGUAGES_WITH_SIGNIFICANT_DIACRITICS.has(this.language)) {
+    token = replaceDiacritics(token)
+  }
+
   // Remove stopwords if enabled
   if (this.stopWordsSet?.has(token)) {
     if (withCache) {
       this.normalizationCache.set(key, '')
     }
     return ''
-  }
-
-  // Fold diacritics BEFORE stemming, so that accented and unaccented surface forms of the same word converge to the same stem (e.g. Portuguese "pão"/"pao" must not stem differently depending on how the user typed it).
-  if (!LANGUAGES_WITH_SIGNIFICANT_DIACRITICS.has(this.language)) {
-    token = replaceDiacritics(token)
   }
 
   // Apply stemming if enabled
@@ -89,6 +89,18 @@ function splitMultilingual(input: string): string[] {
   return input.toLowerCase().match(UNICODE_WORD) ?? []
 }
 
+// Each language's splitter whitelists only the letters of its own alphabet and treats every other
+// character as a separator, so an accent it does not know about does not merely survive into the
+// token — it cuts the word in half ("gâteau" -> "g", "teau" under the English splitter). Folding
+// therefore has to happen here, before the split: `normalizeToken` only ever sees the already
+// shredded pieces. This is safe with respect to word boundaries, since folding can only map a
+// character to a plain ASCII letter, which every splitter whitelists.
+function splitByLanguage(input: string, language: SupportedLanguage): string[] {
+  const lowered = input.toLowerCase()
+  const folded = LANGUAGES_WITH_SIGNIFICANT_DIACRITICS.has(language) ? lowered : replaceDiacritics(lowered)
+  return folded.split(SPLITTERS[language])
+}
+
 function tokenize(
   this: DefaultTokenizer,
   input: string,
@@ -115,7 +127,7 @@ function tokenize(
   const parts =
     this.language === MULTILINGUAL_LANGUAGE
       ? splitMultilingual(input)
-      : input.toLowerCase().split(SPLITTERS[this.language as SupportedLanguage])
+      : splitByLanguage(input, this.language as SupportedLanguage)
   const tokens: string[] = []
   const partsLength = parts.length
 
@@ -197,7 +209,11 @@ export function createTokenizer(config: DefaultTokenizerConfig = {}): DefaultTok
     stemmerSkipProperties: new Set(config.stemmerSkipProperties ? [config.stemmerSkipProperties].flat() : []),
     tokenizeSkipProperties: new Set(config.tokenizeSkipProperties ? [config.tokenizeSkipProperties].flat() : []),
     stopWords,
-    stopWordsSet: stopWords ? new Set(stopWords) : undefined,
+    stopWordsSet: stopWords
+      ? new Set(
+          LANGUAGES_WITH_SIGNIFICANT_DIACRITICS.has(config.language) ? stopWords : stopWords.map(replaceDiacritics)
+        )
+      : undefined,
     allowDuplicates: Boolean(config.allowDuplicates),
     normalizeToken,
     normalizationCache: new Map()

--- a/packages/zbsearch/src/components/tokenizer/index.ts
+++ b/packages/zbsearch/src/components/tokenizer/index.ts
@@ -89,18 +89,6 @@ function splitMultilingual(input: string): string[] {
   return input.toLowerCase().match(UNICODE_WORD) ?? []
 }
 
-// Each language's splitter whitelists only the letters of its own alphabet and treats every other
-// character as a separator, so an accent it does not know about does not merely survive into the
-// token — it cuts the word in half ("gâteau" -> "g", "teau" under the English splitter). Folding
-// therefore has to happen here, before the split: `normalizeToken` only ever sees the already
-// shredded pieces. This is safe with respect to word boundaries, since folding can only map a
-// character to a plain ASCII letter, which every splitter whitelists.
-function splitByLanguage(input: string, language: SupportedLanguage): string[] {
-  const lowered = input.toLowerCase()
-  const folded = LANGUAGES_WITH_SIGNIFICANT_DIACRITICS.has(language) ? lowered : replaceDiacritics(lowered)
-  return folded.split(SPLITTERS[language])
-}
-
 function tokenize(
   this: DefaultTokenizer,
   input: string,
@@ -127,7 +115,7 @@ function tokenize(
   const parts =
     this.language === MULTILINGUAL_LANGUAGE
       ? splitMultilingual(input)
-      : splitByLanguage(input, this.language as SupportedLanguage)
+      : input.toLowerCase().split(SPLITTERS[this.language as SupportedLanguage])
   const tokens: string[] = []
   const partsLength = parts.length
 

--- a/packages/zbsearch/src/components/tokenizer/languages.ts
+++ b/packages/zbsearch/src/components/tokenizer/languages.ts
@@ -41,40 +41,59 @@ export const SUPPORTED_LANGUAGE_LOCALES: Record<string, string> = {
 
 export const MULTILINGUAL_LANGUAGE = 'multilingual' as const
 
-export const SPLITTERS: Record<SupportedLanguage, RegExp> = {
-  dutch: /[^A-Za-zàèéìòóù0-9_'-]+/gim,
-  english: /[^A-Za-zàèéìòóù0-9_'-]+/gim,
-  french: /[^a-z0-9äâàéèëêïîöôùüûœç-]+/gim,
-  italian: /[^A-Za-zàèéìòóù0-9_'-]+/gim,
-  norwegian: /[^a-z0-9_æøåÆØÅäÄöÖüÜ]+/gim,
-  portuguese: /[^a-z0-9à-úÀ-Ú]/gim,
-  russian: /[^a-z0-9а-яА-ЯёЁ]+/gim,
-  spanish: /[^a-z0-9A-Zá-úÁ-ÚñÑüÜ]+/gim,
-  swedish: /[^a-z0-9_åÅäÄöÖüÜ-]+/gim,
-  german: /[^a-z0-9A-ZäöüÄÖÜß]+/gim,
-  finnish: /[^a-z0-9äöÄÖ]+/gim,
-  danish: /[^a-z0-9æøåÆØÅ]+/gim,
-  hungarian: /[^a-z0-9áéíóöőúüűÁÉÍÓÖŐÚÜŰ]+/gim,
-  romanian: /[^a-z0-9ăâîșțĂÂÎȘȚ]+/gim,
-  serbian: /[^a-z0-9čćžšđČĆŽŠĐ]+/gim,
-  turkish: /[^a-z0-9çÇğĞıİöÖşŞüÜ]+/gim,
-  lithuanian: /[^a-z0-9ąčęėįšųūžĄČĘĖĮŠŲŪŽ]+/gim,
-  arabic: /[^a-z0-9ء-ي]+/gim,
-  nepali: /[^a-z0-9अ-ह]+/gim,
-  irish: /[^a-z0-9áéíóúÁÉÍÓÚ]+/gim,
-  indian: /[^a-z0-9अ-ह]+/gim,
-  armenian: /[^a-z0-9ա-ֆ]+/gim,
-  greek: /[^a-z0-9α-ωά-ώ]+/gim,
-  indonesian: /[^a-z0-9]+/gim,
-  ukrainian: /[^a-z0-9а-яА-ЯіїєІЇЄ]+/gim,
-  slovenian: /[^a-z0-9čžšČŽŠ]+/gim,
-  bulgarian: /[^a-z0-9а-яА-Я]+/gim,
-  tamil: /[^a-z0-9அ-ஹ]+/gim,
-  sanskrit: /[^a-z0-9A-Zāīūṛḷṃṁḥśṣṭḍṇṅñḻḹṝ]+/gim,
+// The letters `replaceDiacritics` can fold to plain ASCII: the Latin-1 Supplement and Latin
+// Extended-A blocks (U+00C0–U+017F), minus the × (U+00D7) and ÷ (U+00F7) math symbols that sit
+// inside them and must keep splitting words. Every splitter has to accept these as word
+// characters, including the ones for languages that do not use them: a splitter only whitelists
+// its own alphabet, so an unlisted accent does not merely survive into the token, it cuts the
+// word in half ("gâteau" -> "g", "teau" under the English splitter) during the split — long
+// before `normalizeToken` gets a chance to fold it. Keep in sync with the tables in
+// `diacritics.ts`.
+const FOLDABLE_LETTERS = '\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u017F'
+
+// Per-language alphabets, as character-class bodies. `FOLDABLE_LETTERS` is *prepended* to each one rather than appended, because several of them end in a literal `-` that would otherwise be read as the start of a range.
+const SPLITTER_ALPHABETS: Record<SupportedLanguage, string> = {
+  dutch: "A-Za-zàèéìòóù0-9_'-",
+  english: "A-Za-zàèéìòóù0-9_'-",
+  french: 'a-z0-9äâàéèëêïîöôùüûœç-',
+  italian: "A-Za-zàèéìòóù0-9_'-",
+  norwegian: 'a-z0-9_æøåÆØÅäÄöÖüÜ',
+  portuguese: 'a-z0-9à-úÀ-Ú',
+  russian: 'a-z0-9а-яА-ЯёЁ',
+  spanish: 'a-z0-9A-Zá-úÁ-ÚñÑüÜ',
+  swedish: 'a-z0-9_åÅäÄöÖüÜ-',
+  german: 'a-z0-9A-ZäöüÄÖÜß',
+  finnish: 'a-z0-9äöÄÖ',
+  danish: 'a-z0-9æøåÆØÅ',
+  hungarian: 'a-z0-9áéíóöőúüűÁÉÍÓÖŐÚÜŰ',
+  romanian: 'a-z0-9ăâîșțĂÂÎȘȚ',
+  serbian: 'a-z0-9čćžšđČĆŽŠĐ',
+  turkish: 'a-z0-9çÇğĞıİöÖşŞüÜ',
+  lithuanian: 'a-z0-9ąčęėįšųūžĄČĘĖĮŠŲŪŽ',
+  // U+0671 (ٱ) sits outside the ء-ي range but is folded by `EXTRA_FOLDINGS`, so it belongs here.
+  arabic: 'a-z0-9ء-ي\\u0671',
+  nepali: 'a-z0-9अ-ह',
+  irish: 'a-z0-9áéíóúÁÉÍÓÚ',
+  indian: 'a-z0-9अ-ह',
+  armenian: 'a-z0-9ա-ֆ',
+  greek: 'a-z0-9α-ωά-ώ',
+  indonesian: 'a-z0-9',
+  ukrainian: 'a-z0-9а-яА-ЯіїєІЇЄ',
+  slovenian: 'a-z0-9čžšČŽŠ',
+  bulgarian: 'a-z0-9а-яА-Я',
+  tamil: 'a-z0-9அ-ஹ',
+  sanskrit: 'a-z0-9A-Zāīūṛḷṃṁḥśṣṭḍṇṅñḻḹṝ',
   vietnamese:
-    /[^a-z0-9A-ZáàảãạăắằẳẵặâấầẩẫậéèẻẽẹêếềểễệíìỉĩịóòỏõọôốồổỗộơớờởỡợúùủũụưứừửữựýỳỷỹỵđÁÀẢÃẠĂẮẰẲẴẶÂẤẦẨẪẬÉÈẺẼẸÊẾỀỂỄỆÍÌỈĨỊÓÒỎÕỌÔỐỒỔỖỘƠỚỜỞỠỢÚÙỦŨỤƯỨỪỬỮỰÝỲỶỸỴĐ_]+/gim,
-  czech: /[^A-Z0-9a-zěščřžýáíéúůóťďĚŠČŘŽÝÁÍÉÓÚŮŤĎ-]+/gim
+    'a-z0-9A-ZáàảãạăắằẳẵặâấầẩẫậéèẻẽẹêếềểễệíìỉĩịóòỏõọôốồổỗộơớờởỡợúùủũụưứừửữựýỳỷỹỵđÁÀẢÃẠĂẮẰẲẴẶÂẤẦẨẪẬÉÈẺẼẸÊẾỀỂỄỆÍÌỈĨỊÓÒỎÕỌÔỐỒỔỖỘƠỚỜỞỠỢÚÙỦŨỤƯỨỪỬỮỰÝỲỶỸỴĐ_',
+  czech: 'A-Z0-9a-zěščřžýáíéúůóťďĚŠČŘŽÝÁÍÉÓÚŮŤĎ-'
 }
+
+export const SPLITTERS: Record<SupportedLanguage, RegExp> = Object.fromEntries(
+  Object.entries(SPLITTER_ALPHABETS).map(([language, alphabet]) => [
+    language,
+    new RegExp(`[^${FOLDABLE_LETTERS}${alphabet}]+`, 'gim')
+  ])
+)
 
 export const SUPPORTED_LANGUAGES = Object.keys(SUPPORTED_LANGUAGE_LOCALES)
 

--- a/packages/zbsearch/tests/dataset.test.ts
+++ b/packages/zbsearch/tests/dataset.test.ts
@@ -120,7 +120,7 @@ t.test('zbsearch.dataset', async (t) => {
       properties: ['description']
     })
 
-    t.equal(s1.count, 14979)
+    t.equal(s1.count, 14927)
     t.equal(s2.count, 2926)
     t.equal(s3.count, 3332)
 

--- a/packages/zbsearch/tests/snapshots/events.json
+++ b/packages/zbsearch/tests/snapshots/events.json
@@ -4,7 +4,7 @@
     "hits": [
       {
         "id": "",
-        "score": 5.219060873137768,
+        "score": 5.21736932613558,
         "document": {
           "date": "-53",
           "description": "Parthian war:",
@@ -17,7 +17,7 @@
       },
       {
         "id": "",
-        "score": 4.982684534970456,
+        "score": 4.98037216896867,
         "document": {
           "date": "1728/10/20",
           "description": "The Meerkat–Mongoose war.",
@@ -30,7 +30,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "-156",
           "description": "The first Dalmatian war begins.",
@@ -43,7 +43,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "-119",
           "description": "The second Dalmatian war begins.",
@@ -56,7 +56,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "-78",
           "description": "The Third Dalmatian war begins.",
@@ -69,7 +69,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "599",
           "description": "The Chinese win the war at Ordos.",
@@ -82,7 +82,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1027/08/16",
           "description": "Civil war begins in Japan.",
@@ -95,7 +95,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1695/12/31",
           "description": "Russia declares war on Turkey.",
@@ -108,7 +108,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1792/04/20",
           "description": " France declares war against Austria.",
@@ -121,7 +121,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1792/06/04",
           "description": "Prussia declares war against France.",
@@ -139,7 +139,7 @@
     "hits": [
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1793/03/07",
           "description": " France declares war on Spain.",
@@ -152,7 +152,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1804/12/12",
           "description": " Spain declares war on Britain",
@@ -165,7 +165,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1805/12/26",
           "description": "Sweden declares war on France.",
@@ -178,7 +178,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1823/12/02",
           "description": "Beginning of the first Anglo-Ashanti war.",
@@ -191,7 +191,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1841/04/06",
           "description": "May ampampndash Start of the Sino-Sikh war.",
@@ -204,7 +204,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1854/03/28",
           "description": " France declares war on Russia.",
@@ -217,7 +217,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1878/02/02",
           "description": " Greece declares war on Turkey.",
@@ -230,7 +230,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1914/08/04",
           "description": "Montenegro declares war on Austria-Hungary.",
@@ -243,7 +243,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1914/08/06",
           "description": " Austria-Hungary declares war on Russia.",
@@ -256,7 +256,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1914/08/23",
           "description": " Japan declares war on Germany.",
@@ -274,7 +274,7 @@
     "hits": [
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1933/05/08",
           "description": "Paraguay declares war on Bolivia.",
@@ -287,7 +287,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1941/12/07",
           "description": "Canada declares war on Japan.",
@@ -300,7 +300,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1943/01/16",
           "description": " Iraq declares war on the Axis",
@@ -313,7 +313,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1945/07/14",
           "description": " Italy declares war on Japan.",
@@ -326,7 +326,7 @@
       },
       {
         "id": "",
-        "score": 4.766791898138612,
+        "score": 4.763970493486808,
         "document": {
           "date": "1962/09/26",
           "description": " Civil war erupts in Yemen.",
@@ -339,7 +339,7 @@
       },
       {
         "id": "",
-        "score": 4.568830948804273,
+        "score": 4.565591416853025,
         "document": {
           "date": "17/05/26",
           "description": "Beginning of a civil war in Germania.",
@@ -352,7 +352,7 @@
       },
       {
         "id": "",
-        "score": 4.568830948804273,
+        "score": 4.565591416853025,
         "document": {
           "date": "350/12/25",
           "description": "The Wei-Jie war breaks out in North China.",
@@ -365,7 +365,7 @@
       },
       {
         "id": "",
-        "score": 4.568830948804273,
+        "score": 4.565591416853025,
         "document": {
           "date": "618",
           "description": "A civil war begins in Medina.",
@@ -378,7 +378,7 @@
       },
       {
         "id": "",
-        "score": 4.568830948804273,
+        "score": 4.565591416853025,
         "document": {
           "date": "1240/07/15",
           "description": "The civil war era in Norway ends.",
@@ -391,7 +391,7 @@
       },
       {
         "id": "",
-        "score": 4.568830948804273,
+        "score": 4.565591416853025,
         "document": {
           "date": "1635/04/13",
           "description": "May ampampndash France declares war on Spain.",

--- a/packages/zbsearch/tests/tokenizer.test.ts
+++ b/packages/zbsearch/tests/tokenizer.test.ts
@@ -188,7 +188,7 @@ t.test('Tokenizer', async (t) => {
     const O2 = tokenizer.tokenize(I2)
 
     t.strictSame(O1, ['cozinh', 'alguns', 'bol'])
-    t.strictSame(O2, ['dorm', 'e', 'cois', 'dificil', 'test', 'falh'])
+    t.strictSame(O2, ['dorm', 'cois', 'dificil', 'test', 'falh'])
   })
 
   t.test('should tokenize and stem correctly in russian', async (t) => {
@@ -662,5 +662,40 @@ t.test('Custom stop-words rules', async (t) => {
     // like آلاف and قراءة were shredded into fragments.
     t.strictSame(tokenizer.tokenize('آلاف'), ['الاف'])
     t.strictSame(tokenizer.tokenize('قراءة'), ['قراءة'])
+  })
+
+  t.test('foreign accents do not split words apart', async (t) => {
+    for (const language of ['english', 'dutch', 'italian', 'french', 'german', 'portuguese', 'spanish'] as const) {
+      const tokenizer = createTokenizer({ language })
+
+      t.strictSame(
+        tokenizer.tokenize('Invitation gâteau au chocolat'),
+        ['invitation', 'gateau', 'au', 'chocolat'],
+        `${language}: accented word survives as one token`
+      )
+      t.strictSame(
+        tokenizer.tokenize('Gateau'),
+        tokenizer.tokenize('Gâteau'),
+        `${language}: accented and unaccented queries produce the same token`
+      )
+      t.strictSame(tokenizer.tokenize('Crème brûlée'), ['creme', 'brulee'], `${language}: folds every accent`)
+    }
+  })
+
+  t.test('languages with significant diacritics are still not folded', async (t) => {
+    const tokenizer = createTokenizer({ language: 'vietnamese' })
+
+    // Vietnamese tone marks change the meaning of a word, so "tài" must not collapse onto "tai".
+    t.strictSame(tokenizer.tokenize('tài'), ['tài'])
+    t.strictSame(tokenizer.tokenize('tai'), ['tai'])
+  })
+
+  t.test('accented stopwords are still filtered out once tokens are folded', async (t) => {
+    const tokenizer = createTokenizer({ language: 'french', stopWords: ['où', 'été'] })
+
+    t.strictSame(tokenizer.tokenize('Où est le gâteau été'), ['est', 'le', 'gateau'])
+    // The unaccented spelling of a stopword is dropped too, so a query typed
+    // without accents behaves exactly like the accented one.
+    t.strictSame(tokenizer.tokenize('Ou est le gateau ete'), ['est', 'le', 'gateau'])
   })
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core tokenization for all indexed and queried text, which can shift match counts and scores; behavior is intentional but affects search relevance across languages.
> 
> **Overview**
> Fixes **accent-insensitive search** (e.g. querying `Gateau` against `gâteau`) by changing how the default tokenizer handles diacritics, which also fixes PluginPT15/QPS behavior tied to issue #995.
> 
> **Diacritic folding now runs before language splitting**, via new `splitByLanguage`: language splitters only whitelist their own letters, so unknown accents used to **break words** (e.g. English splitting `gâteau` into `g` and `teau`). Folding first keeps whole words like `gateau`.
> 
> **Folding order in `normalizeToken`** is updated so diacritics are removed **before** stopword checks and stemming, so accented and unaccented forms share the same stem and stopword behavior. **`stopWordsSet`** is built from folded stopwords for non–significant-diacritic languages so queries without accents still drop the same stopwords.
> 
> **Vietnamese** (and other languages with significant diacritics) still do **not** fold at split/normalize. Dataset snapshot counts/scores shift slightly from tokenization changes; new tests cover tokenizer, PT15, and QPS accented queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9355619f97d47ac38d8c8e935a4b116846991bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->